### PR TITLE
limes: add QuotaDistributionModel enum

### DIFF
--- a/limes/resources/report_cluster.go
+++ b/limes/resources/report_cluster.go
@@ -48,14 +48,15 @@ type ClusterServiceReport struct {
 type ClusterResourceReport struct {
 	//Several fields are pointers to values to enable precise control over which fields are rendered in output.
 	ResourceInfo
-	Capacity      *uint64                        `json:"capacity,omitempty"`
-	RawCapacity   *uint64                        `json:"raw_capacity,omitempty"`
-	CapacityPerAZ ClusterAvailabilityZoneReports `json:"per_availability_zone,omitempty"`
-	DomainsQuota  *uint64                        `json:"domains_quota,omitempty"`
-	Usage         uint64                         `json:"usage"`
-	BurstUsage    uint64                         `json:"burst_usage,omitempty"`
-	PhysicalUsage *uint64                        `json:"physical_usage,omitempty"`
-	Subcapacities json.RawMessage                `json:"subcapacities,omitempty"`
+	QuotaDistributionModel QuotaDistributionModel         `json:"quota_distribution_model,omitempty"`
+	Capacity               *uint64                        `json:"capacity,omitempty"`
+	RawCapacity            *uint64                        `json:"raw_capacity,omitempty"`
+	CapacityPerAZ          ClusterAvailabilityZoneReports `json:"per_availability_zone,omitempty"`
+	DomainsQuota           *uint64                        `json:"domains_quota,omitempty"`
+	Usage                  uint64                         `json:"usage"`
+	BurstUsage             uint64                         `json:"burst_usage,omitempty"`
+	PhysicalUsage          *uint64                        `json:"physical_usage,omitempty"`
+	Subcapacities          json.RawMessage                `json:"subcapacities,omitempty"`
 }
 
 // ClusterAvailabilityZoneReport is a substructure of ClusterResourceReport containing

--- a/limes/resources/report_domain.go
+++ b/limes/resources/report_domain.go
@@ -42,14 +42,15 @@ type DomainServiceReport struct {
 type DomainResourceReport struct {
 	//Several fields are pointers to values to enable precise control over which fields are rendered in output.
 	ResourceInfo
-	DomainQuota          *uint64          `json:"quota,omitempty"`
-	ProjectsQuota        *uint64          `json:"projects_quota,omitempty"`
-	Usage                uint64           `json:"usage"`
-	BurstUsage           uint64           `json:"burst_usage,omitempty"`
-	PhysicalUsage        *uint64          `json:"physical_usage,omitempty"`
-	BackendQuota         *uint64          `json:"backend_quota,omitempty"`
-	InfiniteBackendQuota *bool            `json:"infinite_backend_quota,omitempty"`
-	Scaling              *ScalingBehavior `json:"scales_with,omitempty"`
+	QuotaDistributionModel QuotaDistributionModel `json:"quota_distribution_model,omitempty"`
+	DomainQuota            *uint64                `json:"quota,omitempty"`
+	ProjectsQuota          *uint64                `json:"projects_quota,omitempty"`
+	Usage                  uint64                 `json:"usage"`
+	BurstUsage             uint64                 `json:"burst_usage,omitempty"`
+	PhysicalUsage          *uint64                `json:"physical_usage,omitempty"`
+	BackendQuota           *uint64                `json:"backend_quota,omitempty"`
+	InfiniteBackendQuota   *bool                  `json:"infinite_backend_quota,omitempty"`
+	Scaling                *ScalingBehavior       `json:"scales_with,omitempty"`
 	//Annotations may contain arbitrary metadata that was configured for this
 	//resource in this scope by Limes' operator.
 	Annotations map[string]interface{} `json:"annotations,omitempty"`

--- a/limes/resources/report_project.go
+++ b/limes/resources/report_project.go
@@ -53,14 +53,16 @@ type ProjectServiceReport struct {
 type ProjectResourceReport struct {
 	//Several fields are pointers to values to enable precise control over which fields are rendered in output.
 	ResourceInfo
-	Quota         *uint64          `json:"quota,omitempty"`
-	UsableQuota   *uint64          `json:"usable_quota,omitempty"`
-	Usage         uint64           `json:"usage"`
-	BurstUsage    uint64           `json:"burst_usage,omitempty"`
-	PhysicalUsage *uint64          `json:"physical_usage,omitempty"`
-	BackendQuota  *int64           `json:"backend_quota,omitempty"`
-	Subresources  json.RawMessage  `json:"subresources,omitempty"`
-	Scaling       *ScalingBehavior `json:"scales_with,omitempty"`
+	QuotaDistributionModel QuotaDistributionModel `json:"quota_distribution_model,omitempty"`
+	Quota                  *uint64                `json:"quota,omitempty"`
+	DefaultQuota           *uint64                `json:"default_quota,omitempty"`
+	UsableQuota            *uint64                `json:"usable_quota,omitempty"`
+	Usage                  uint64                 `json:"usage"`
+	BurstUsage             uint64                 `json:"burst_usage,omitempty"`
+	PhysicalUsage          *uint64                `json:"physical_usage,omitempty"`
+	BackendQuota           *int64                 `json:"backend_quota,omitempty"`
+	Subresources           json.RawMessage        `json:"subresources,omitempty"`
+	Scaling                *ScalingBehavior       `json:"scales_with,omitempty"`
 	//Annotations may contain arbitrary metadata that was configured for this
 	//resource in this scope by Limes' operator.
 	Annotations map[string]interface{} `json:"annotations,omitempty"`


### PR DESCRIPTION
Companion PR for https://github.com/sapcc/limes/pull/264. The QuotaDistributionModel must become part of the public API because we will adjust the display and behavior of the UI controls in Elektra based on it.