### PR TITLE
[WIP] Generalize helmevent to tensoevent

### DIFF
--- a/tensoevent/tensoevent.go
+++ b/tensoevent/tensoevent.go
@@ -17,9 +17,9 @@
 *
 *******************************************************************************/
 
-// Package helmevent contains data structures describing the event messages that
-// our CI generates for Helm deployments (i.e. "helm install" and "helm upgrade".
-package helmevent
+// Package tensoevent contains data structures describing the event messages that
+// our CI generates for deployments (i.e. "helm install" and "helm upgrade".
+package tensoevent
 
 import (
 	"time"
@@ -29,10 +29,13 @@ import (
 type Event struct {
 	Region string `json:"region"`
 	//NOTE: This should be "recorded-at". The inconsistent naming needs to stay like this now for backwards compatibility.
-	RecordedAt   *time.Time         `json:"recorded_at"`
-	GitRepos     map[string]GitRepo `json:"git"`
-	HelmReleases []*HelmRelease     `json:"helm-release"`
-	Pipeline     Pipeline           `json:"pipeline"`
+	RecordedAt *time.Time         `json:"recorded_at"`
+	GitRepos   map[string]GitRepo `json:"git"`
+	// Note one of the *Release Types MUST be set
+	HelmReleases []*HelmRelease `json:"helm-release,omitempty"`
+	// this should be tf-releases but is named release for consistency
+	TFReleases []*TFRelease `json:"tf-release,omitempty"`
+	Pipeline   Pipeline     `json:"pipeline"`
 }
 
 // GitRepo appears in type Event. It describes the state of a Git repository
@@ -43,6 +46,23 @@ type GitRepo struct {
 	CommittedAt *time.Time `json:"committed-at"`
 	CommitID    string     `json:"commit-id"`
 	RemoteURL   string     `json:"remote-url"`
+}
+
+// TFRelease appears in type Event. It describes a terraform run that was executed and it's outcome
+type TFRelease struct {
+	TFVersion       string          `json:"tf_version"`
+	TFChangeSummary TFChangeSummary `json:"tf_change_summary,omitempty"`
+	TFError         string          `json:"tf_error,omitempty"`
+	Outcome         Outcome         `json:"outcome"`
+}
+
+// TFChangeSummary appears in TFRelease. It describes how many resources were added / destroyed or changed by
+// a terraform run
+type TFChangeSummary struct {
+	Add       int    `json:"add"`
+	Change    int    `json:"change"`
+	Remove    int    `json:"remove"`
+	Operation string `json:"operation"`
 }
 
 // HelmRelease appears in type Event. It describes a Helm release that was
@@ -70,7 +90,7 @@ type HelmRelease struct {
 	DurationSeconds *uint64    `json:"duration,omitempty"`
 }
 
-// Outcome appears in type HelmRelease. It describes the final state of a Helm release.
+// Outcome appears in type HelmRelease and TFRelease. It describes the final state of a release.
 type Outcome string
 
 const (
@@ -79,6 +99,8 @@ const (
 	OutcomeNotDeployed Outcome = "not-deployed"
 	//OutcomeSucceeded describes a Helm release that succeeded.
 	OutcomeSucceeded Outcome = "succeeded"
+	//OutcomeFailed describes a failed release
+	OutcomeFailed Outcome = "failed"
 	//OutcomeHelmUpgradeFailed describes a Helm release that failed during
 	//`helm upgrade` or because some deployed pods did not come up correctly.
 	OutcomeHelmUpgradeFailed Outcome = "helm-upgrade-failed"
@@ -122,7 +144,7 @@ func (event Event) CombinedOutcome() Outcome {
 	hasUndeployed := false
 	for _, hr := range event.HelmReleases {
 		switch hr.Outcome {
-		case OutcomeHelmUpgradeFailed, OutcomeE2ETestFailed:
+		case OutcomeHelmUpgradeFailed, OutcomeE2ETestFailed, OutcomeFailed:
 			//specific failure forces the entire result to be that failure
 			return hr.Outcome
 		case OutcomeSucceeded:


### PR DESCRIPTION
i need to add terraform runs to the tenso events and want to use the concourse release resources

i moved the helmevent package into tensoevent and made the helm releases field nullable.
i then added the TFRelease struct and it's dependencies to it.