### PR TITLE
CADF: Name in resource field is not supported in all events. Omitempty

### DIFF
--- a/cadf/event.go
+++ b/cadf/event.go
@@ -76,7 +76,7 @@ type Event struct {
 // Resource contains attributes describing a (OpenStack-) Resource
 type Resource struct {
 	TypeURI   string `json:"typeURI"`
-	Name      string `json:"name"`
+  Name      string `json:"name,omitempty"`
 	Domain    string `json:"domain,omitempty"`
 	ID        string `json:"id"`
 	Addresses []struct {

--- a/cadf/event.go
+++ b/cadf/event.go
@@ -76,7 +76,7 @@ type Event struct {
 // Resource contains attributes describing a (OpenStack-) Resource
 type Resource struct {
 	TypeURI   string `json:"typeURI"`
-  Name      string `json:"name,omitempty"`
+	Name      string `json:"name,omitempty"`
 	Domain    string `json:"domain,omitempty"`
 	ID        string `json:"id"`
 	Addresses []struct {


### PR DESCRIPTION
Name is not supported in all events as a resource. It needs to be omitempty to not show a blank name where it is unavailable. 

I will also be adding more support for the name field through metis enrichment. However even in the case that this is unavailable, it needs to not show up as empty as it's confusing for customers. 