### PR TITLE
limes: add PerAZ fields to ClusterResourceReport and ProjectResourceReport

### DIFF
--- a/limes/resources/report_cluster.go
+++ b/limes/resources/report_cluster.go
@@ -48,15 +48,18 @@ type ClusterServiceReport struct {
 type ClusterResourceReport struct {
 	//Several fields are pointers to values to enable precise control over which fields are rendered in output.
 	ResourceInfo
-	QuotaDistributionModel QuotaDistributionModel         `json:"quota_distribution_model,omitempty"`
-	Capacity               *uint64                        `json:"capacity,omitempty"`
-	RawCapacity            *uint64                        `json:"raw_capacity,omitempty"`
-	CapacityPerAZ          ClusterAvailabilityZoneReports `json:"per_availability_zone,omitempty"`
-	DomainsQuota           *uint64                        `json:"domains_quota,omitempty"`
-	Usage                  uint64                         `json:"usage"`
-	BurstUsage             uint64                         `json:"burst_usage,omitempty"`
-	PhysicalUsage          *uint64                        `json:"physical_usage,omitempty"`
-	Subcapacities          json.RawMessage                `json:"subcapacities,omitempty"`
+	QuotaDistributionModel QuotaDistributionModel `json:"quota_distribution_model,omitempty"`
+	Capacity               *uint64                `json:"capacity,omitempty"`
+	RawCapacity            *uint64                `json:"raw_capacity,omitempty"`
+	//PerAZ is only rendered by Limes when the v2 API feature preview is enabled.
+	//In this case, CapacityPerAZ will be omitted.
+	PerAZ         ClusterAZResourceReports       `json:"per_az,omitempty"`
+	CapacityPerAZ ClusterAvailabilityZoneReports `json:"per_availability_zone,omitempty"`
+	DomainsQuota  *uint64                        `json:"domains_quota,omitempty"`
+	Usage         uint64                         `json:"usage"`
+	BurstUsage    uint64                         `json:"burst_usage,omitempty"`
+	PhysicalUsage *uint64                        `json:"physical_usage,omitempty"`
+	Subcapacities json.RawMessage                `json:"subcapacities,omitempty"`
 }
 
 // ClusterAvailabilityZoneReport is a substructure of ClusterResourceReport containing
@@ -66,6 +69,16 @@ type ClusterAvailabilityZoneReport struct {
 	Capacity    uint64                 `json:"capacity"`
 	RawCapacity uint64                 `json:"raw_capacity,omitempty"`
 	Usage       uint64                 `json:"usage,omitempty"`
+}
+
+// ClusterAZResourceReport is a substructure of ClusterResourceReport containing
+// capacity and usage data for a single resource in an availability zone.
+//
+// This type is part of the v2 API feature preview.
+type ClusterAZResourceReport struct {
+	Capacity    uint64  `json:"capacity"`
+	RawCapacity uint64  `json:"raw_capacity,omitempty"`
+	Usage       *uint64 `json:"usage,omitempty"`
 }
 
 // ClusterServiceReports provides fast lookup of services by service type, but
@@ -79,3 +92,7 @@ type ClusterResourceReports map[string]*ClusterResourceReport
 // ClusterAvailabilityZoneReports provides fast lookup of availability zones
 // using a map, but serializes to JSON as a list.
 type ClusterAvailabilityZoneReports map[limes.AvailabilityZone]*ClusterAvailabilityZoneReport
+
+// ClusterAZResourceReport is a substructure of ClusterResourceReport that breaks
+// down capacity and usage data for a single resource by availability zone.
+type ClusterAZResourceReports map[limes.AvailabilityZone]ClusterAZResourceReport

--- a/limes/resources/report_cluster_test.go
+++ b/limes/resources/report_cluster_test.go
@@ -30,6 +30,16 @@ var clusterServicesMockJSON = `
 				{
 					"name": "cores",
 					"capacity": 500,
+					"per_az": {
+						"az-one": {
+							"capacity": 250,
+							"usage": 70
+						},
+						"az-two": {
+							"capacity": 250,
+							"usage": 30
+						}
+					},
 					"per_availability_zone": [
 						{
 							"name": "az-one",
@@ -64,6 +74,16 @@ var clusterResourcesMockJSON = `
 		{
 			"name": "cores",
 			"capacity": 500,
+			"per_az": {
+				"az-one": {
+					"capacity": 250,
+					"usage": 70
+				},
+				"az-two": {
+					"capacity": 250,
+					"usage": 30
+				}
+			},
 			"per_availability_zone": [
 				{
 					"name": "az-one",
@@ -95,6 +115,16 @@ var clusterMockResources = &ClusterResourceReports{
 			Name: "cores",
 		},
 		Capacity: &coresCap,
+		PerAZ: map[limes.AvailabilityZone]ClusterAZResourceReport{
+			"az-one": {
+				Capacity: 250,
+				Usage:    p2u64(70),
+			},
+			"az-two": {
+				Capacity: 250,
+				Usage:    p2u64(30),
+			},
+		},
 		CapacityPerAZ: ClusterAvailabilityZoneReports{
 			"az-one": {
 				Name:     "az-one",

--- a/limes/resources/report_project.go
+++ b/limes/resources/report_project.go
@@ -55,18 +55,35 @@ type ProjectResourceReport struct {
 	ResourceInfo
 	QuotaDistributionModel QuotaDistributionModel   `json:"quota_distribution_model,omitempty"`
 	CommitmentConfig       *CommitmentConfiguration `json:"commitment_config,omitempty"`
-	Quota                  *uint64                  `json:"quota,omitempty"`
-	DefaultQuota           *uint64                  `json:"default_quota,omitempty"`
-	UsableQuota            *uint64                  `json:"usable_quota,omitempty"`
-	Usage                  uint64                   `json:"usage"`
-	BurstUsage             uint64                   `json:"burst_usage,omitempty"`
-	PhysicalUsage          *uint64                  `json:"physical_usage,omitempty"`
-	BackendQuota           *int64                   `json:"backend_quota,omitempty"`
-	Subresources           json.RawMessage          `json:"subresources,omitempty"`
-	Scaling                *ScalingBehavior         `json:"scales_with,omitempty"`
+	//PerAZ is only rendered by Limes when the v2 API feature preview is enabled.
+	PerAZ         ProjectAZResourceReports `json:"per_az,omitempty"`
+	Quota         *uint64                  `json:"quota,omitempty"`
+	DefaultQuota  *uint64                  `json:"default_quota,omitempty"`
+	UsableQuota   *uint64                  `json:"usable_quota,omitempty"`
+	Usage         uint64                   `json:"usage"`
+	BurstUsage    uint64                   `json:"burst_usage,omitempty"`
+	PhysicalUsage *uint64                  `json:"physical_usage,omitempty"`
+	BackendQuota  *int64                   `json:"backend_quota,omitempty"`
+	Subresources  json.RawMessage          `json:"subresources,omitempty"`
+	Scaling       *ScalingBehavior         `json:"scales_with,omitempty"`
 	//Annotations may contain arbitrary metadata that was configured for this
 	//resource in this scope by Limes' operator.
 	Annotations map[string]any `json:"annotations,omitempty"`
+}
+
+// ProjectAZResourceReport is a substructure of ProjectResourceReport containing
+// quota and usage data for a single resource in an availability zone.
+//
+// This type is part of the v2 API feature preview.
+type ProjectAZResourceReport struct {
+	Quota *uint64 `json:"quota,omitempty"`
+	// The keys for the Committed map must be commitment durations as accepted
+	// by func ParseCommitmentDuration. We cannot use type CommitmentDuration
+	// directly here because Go does not allow struct types as map keys.
+	Committed     map[string]uint64 `json:"committed,omitempty"`
+	Usage         uint64            `json:"usage"`
+	PhysicalUsage *uint64           `json:"physical_usage,omitempty"`
+	Subresources  json.RawMessage   `json:"subresources,omitempty"`
 }
 
 // ProjectServiceReports provides fast lookup of services using a map, but serializes
@@ -76,3 +93,7 @@ type ProjectServiceReports map[string]*ProjectServiceReport
 // ProjectResourceReports provides fast lookup of resources using a map, but serializes
 // to JSON as a list.
 type ProjectResourceReports map[string]*ProjectResourceReport
+
+// ProjectAZResourceReport is a substructure of ProjectResourceReport that breaks
+// down quota and usage data for a single resource by availability zone.
+type ProjectAZResourceReports map[limes.AvailabilityZone]ProjectAZResourceReport

--- a/limes/resources/report_project_test.go
+++ b/limes/resources/report_project_test.go
@@ -31,12 +31,30 @@ var projectServicesMockJSON = `
 				{
 					"name": "capacity",
 					"unit": "B",
+					"per_az": {
+						"az-one": {
+							"quota": 6,
+							"committed": {
+								"1 year": 3
+							},
+							"usage": 2
+						},
+						"az-two": {
+							"quota": 4,
+							"usage": 0
+						}
+					},
 					"quota": 10,
 					"usable_quota": 11,
 					"usage": 2
 				},
 				{
 					"name": "things",
+					"per_az": {
+						"any": {
+							"usage": 2
+						}
+					},
 					"quota": 10,
 					"usable_quota": 10,
 					"usage": 2
@@ -52,6 +70,19 @@ var projectResourcesMockJSON = `
 		{
 			"name": "capacity",
 			"unit": "B",
+			"per_az": {
+				"az-one": {
+					"quota": 6,
+					"committed": {
+						"1 year": 3
+					},
+					"usage": 2
+				},
+				"az-two": {
+					"quota": 4,
+					"usage": 0
+				}
+			},
 			"quota": 10,
 			"usable_quota": 11,
 			"usage": 2
@@ -59,6 +90,11 @@ var projectResourcesMockJSON = `
 		{
 			"name": "things",
 			"quota": 10,
+			"per_az": {
+				"any": {
+					"usage": 2
+				}
+			},
 			"usable_quota": 10,
 			"usage": 2
 		}
@@ -71,6 +107,10 @@ var projectMockResources = &ProjectResourceReports{
 			Name: "capacity",
 			Unit: limes.UnitBytes,
 		},
+		PerAZ: ProjectAZResourceReports{
+			"az-one": {Quota: p2u64(6), Usage: 2, Committed: map[string]uint64{"1 year": 3}},
+			"az-two": {Quota: p2u64(4), Usage: 0},
+		},
 		Quota:       p2u64(10),
 		UsableQuota: p2u64(11),
 		Usage:       2,
@@ -78,6 +118,9 @@ var projectMockResources = &ProjectResourceReports{
 	"things": &ProjectResourceReport{
 		ResourceInfo: ResourceInfo{
 			Name: "things",
+		},
+		PerAZ: ProjectAZResourceReports{
+			limes.AvailabilityZoneAny: {Usage: 2},
 		},
 		Quota:       p2u64(10),
 		UsableQuota: p2u64(10),


### PR DESCRIPTION
On the cluster level, this is separate from the existing CapacityPerAZ field in order to fix a typing mistake: Usage on a cluster resource should be a pointer because we have cluster resources with unknown usage (which ought to be distinct from zero usage).

For the new fields, I have decided to break tradition and not encode the maps as lists like we do for services and resources. The encoding as lists was mostly based on my own cargo-culting of how the OpenStack API works. I won't go back and break all existing users of the services and resources by changing them to maps, but on new fields like this, I will prefer maps now because they align better with the code we write to generate and process those structures.