### PR TITLE
limes: add additional aggregations of commitment numbers

### DIFF
--- a/limes/resources/report_cluster.go
+++ b/limes/resources/report_cluster.go
@@ -48,9 +48,10 @@ type ClusterServiceReport struct {
 type ClusterResourceReport struct {
 	//Several fields are pointers to values to enable precise control over which fields are rendered in output.
 	ResourceInfo
-	QuotaDistributionModel QuotaDistributionModel `json:"quota_distribution_model,omitempty"`
-	Capacity               *uint64                `json:"capacity,omitempty"`
-	RawCapacity            *uint64                `json:"raw_capacity,omitempty"`
+	QuotaDistributionModel QuotaDistributionModel   `json:"quota_distribution_model,omitempty"`
+	CommitmentConfig       *CommitmentConfiguration `json:"commitment_config,omitempty"`
+	Capacity               *uint64                  `json:"capacity,omitempty"`
+	RawCapacity            *uint64                  `json:"raw_capacity,omitempty"`
 	//PerAZ is only rendered by Limes when the v2 API feature preview is enabled.
 	//In this case, CapacityPerAZ will be omitted.
 	PerAZ         ClusterAZResourceReports       `json:"per_az,omitempty"`
@@ -79,9 +80,17 @@ type ClusterAZResourceReport struct {
 	Capacity    uint64 `json:"capacity"`
 	RawCapacity uint64 `json:"raw_capacity,omitempty"`
 	//Usage is what the backend reports. This is only shown if the backend does indeed report a summarized cluster-wide usage level.
+	//TODO: rename this to "backend_usage" in v2
 	Usage *uint64 `json:"usage,omitempty"`
 	//ProjectsUsage is the aggregate of the usage across all projects, as reported by the backend on the project level.
+	//TODO: rename this to "usage" in v2 (to be consistent with domain and project level)
 	ProjectsUsage uint64 `json:"projects_usage,omitempty"`
+	// The keys for these maps must be commitment durations as accepted
+	// by func ParseCommitmentDuration. We cannot use type CommitmentDuration
+	// directly here because Go does not allow struct types as map keys.
+	UnusedCommitments  map[string]uint64 `json:"unused_commitments,omitempty"`
+	PendingCommitments map[string]uint64 `json:"pending_commitments,omitempty"`
+	PlannedCommitments map[string]uint64 `json:"planned_commitments,omitempty"`
 	//PhysicalUsage is collected per project and then aggregated, same as ProjectsUsage.
 	PhysicalUsage *uint64         `json:"physical_usage,omitempty"`
 	Subcapacities json.RawMessage `json:"subcapacities,omitempty"`

--- a/limes/resources/report_domain.go
+++ b/limes/resources/report_domain.go
@@ -42,18 +42,36 @@ type DomainServiceReport struct {
 type DomainResourceReport struct {
 	//Several fields are pointers to values to enable precise control over which fields are rendered in output.
 	ResourceInfo
-	QuotaDistributionModel QuotaDistributionModel `json:"quota_distribution_model,omitempty"`
-	DomainQuota            *uint64                `json:"quota,omitempty"`
-	ProjectsQuota          *uint64                `json:"projects_quota,omitempty"`
-	Usage                  uint64                 `json:"usage"`
-	BurstUsage             uint64                 `json:"burst_usage,omitempty"`
-	PhysicalUsage          *uint64                `json:"physical_usage,omitempty"`
-	BackendQuota           *uint64                `json:"backend_quota,omitempty"`
-	InfiniteBackendQuota   *bool                  `json:"infinite_backend_quota,omitempty"`
-	Scaling                *ScalingBehavior       `json:"scales_with,omitempty"`
+	QuotaDistributionModel QuotaDistributionModel   `json:"quota_distribution_model,omitempty"`
+	CommitmentConfig       *CommitmentConfiguration `json:"commitment_config,omitempty"`
+	//PerAZ is only rendered by Limes when the v2 API feature preview is enabled.
+	PerAZ                DomainAZResourceReports `json:"per_az,omitempty"`
+	DomainQuota          *uint64                 `json:"quota,omitempty"`
+	ProjectsQuota        *uint64                 `json:"projects_quota,omitempty"`
+	Usage                uint64                  `json:"usage"`
+	BurstUsage           uint64                  `json:"burst_usage,omitempty"`
+	PhysicalUsage        *uint64                 `json:"physical_usage,omitempty"`
+	BackendQuota         *uint64                 `json:"backend_quota,omitempty"`
+	InfiniteBackendQuota *bool                   `json:"infinite_backend_quota,omitempty"`
+	Scaling              *ScalingBehavior        `json:"scales_with,omitempty"`
 	//Annotations may contain arbitrary metadata that was configured for this
 	//resource in this scope by Limes' operator.
 	Annotations map[string]any `json:"annotations,omitempty"`
+}
+
+// DomainAZResourceReport is a substructure of DomainResourceReport containing
+// quota and usage data for a single resource in an availability zone.
+//
+// This type is part of the v2 API feature preview.
+type DomainAZResourceReport struct {
+	Quota *uint64 `json:"quota,omitempty"`
+	Usage uint64  `json:"usage"`
+	// The keys for these maps must be commitment durations as accepted
+	// by func ParseCommitmentDuration. We cannot use type CommitmentDuration
+	// directly here because Go does not allow struct types as map keys.
+	UnusedCommitments  map[string]uint64 `json:"unused_commitments,omitempty"`
+	PendingCommitments map[string]uint64 `json:"pending_commitments,omitempty"`
+	PlannedCommitments map[string]uint64 `json:"planned_commitments,omitempty"`
 }
 
 // DomainServiceReports provides fast lookup of services using a map, but serializes
@@ -63,3 +81,7 @@ type DomainServiceReports map[string]*DomainServiceReport
 // DomainResourceReports provides fast lookup of resources using a map, but serializes
 // to JSON as a list.
 type DomainResourceReports map[string]*DomainResourceReport
+
+// DomainAZResourceReport is a substructure of DomainResourceReport that breaks
+// down quota and usage data for a single resource by availability zone.
+type DomainAZResourceReports map[limes.AvailabilityZone]*DomainAZResourceReport

--- a/limes/resources/report_project.go
+++ b/limes/resources/report_project.go
@@ -76,13 +76,15 @@ type ProjectResourceReport struct {
 // This type is part of the v2 API feature preview.
 type ProjectAZResourceReport struct {
 	Quota *uint64 `json:"quota,omitempty"`
-	// The keys for the Committed map must be commitment durations as accepted
+	// The keys for these maps must be commitment durations as accepted
 	// by func ParseCommitmentDuration. We cannot use type CommitmentDuration
 	// directly here because Go does not allow struct types as map keys.
-	Committed     map[string]uint64 `json:"committed,omitempty"`
-	Usage         uint64            `json:"usage"`
-	PhysicalUsage *uint64           `json:"physical_usage,omitempty"`
-	Subresources  json.RawMessage   `json:"subresources,omitempty"`
+	Committed          map[string]uint64 `json:"committed,omitempty"`
+	PendingCommitments map[string]uint64 `json:"pending_commitments,omitempty"`
+	PlannedCommitments map[string]uint64 `json:"planned_commitments,omitempty"`
+	Usage              uint64            `json:"usage"`
+	PhysicalUsage      *uint64           `json:"physical_usage,omitempty"`
+	Subresources       json.RawMessage   `json:"subresources,omitempty"`
 }
 
 // ProjectServiceReports provides fast lookup of services using a map, but serializes


### PR DESCRIPTION
As discussed earlier today.

For the domain-level and cloud-level UIs, they will serve to generate overviews, before drilling down into the commitments of specific projects.

For the project-level UI, they will remove the need for the UI to query for the full list of commitments only to mark resources that have pending or planned commitments at all.