### PR TITLE
limes: move ParseQuotaOverrides function down a few layers

### DIFF
--- a/limes/resources/overrides.go
+++ b/limes/resources/overrides.go
@@ -1,0 +1,90 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package limesresources
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/sapcc/go-api-declarations/limes"
+)
+
+// ParseQuotaOverrides parses the contents of a quota-overrides.json file.
+// This is the format expected by Limes at $LIMES_QUOTA_OVERRIDES_PATH.
+// This code lives here because it is also used in `limesctl validate-quota-overrides`.
+func ParseQuotaOverrides(buf []byte, getUnit func(limes.ServiceType, ResourceName) (limes.Unit, error)) (result map[string]map[string]map[limes.ServiceType]map[ResourceName]uint64, errs []error) {
+	var parsed map[string]map[string]map[limes.ServiceType]map[ResourceName]json.RawMessage
+	err := json.Unmarshal(buf, &parsed)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	result = make(map[string]map[string]map[limes.ServiceType]map[ResourceName]uint64)
+	for domainName, domainInputs := range parsed {
+		domainResult := make(map[string]map[limes.ServiceType]map[ResourceName]uint64)
+		for projectName, projectInputs := range domainInputs {
+			projectResult := make(map[limes.ServiceType]map[ResourceName]uint64)
+			for serviceType, serviceInputs := range projectInputs {
+				serviceResult := make(map[ResourceName]uint64)
+				for resourceName, inputJSON := range serviceInputs {
+					unit, err := getUnit(serviceType, resourceName)
+					if err != nil {
+						errs = append(errs, err)
+						continue
+					}
+					value, err := parseSingleQuotaOverrideValue(inputJSON, serviceType, resourceName, unit)
+					if err == nil {
+						serviceResult[resourceName] = value
+					} else {
+						errs = append(errs, err)
+					}
+				}
+				projectResult[serviceType] = serviceResult
+			}
+			domainResult[projectName] = projectResult
+		}
+		result[domainName] = domainResult
+	}
+	return result, errs
+}
+
+func parseSingleQuotaOverrideValue(input json.RawMessage, serviceType limes.ServiceType, resourceName ResourceName, unit limes.Unit) (uint64, error) {
+	// case 1: counted resources represent quota as a single number
+	if unit == limes.UnitNone {
+		var value uint64
+		err := json.Unmarshal([]byte(input), &value)
+		if err != nil {
+			return 0, fmt.Errorf("expected uint64 value for %s/%s, but got %q", serviceType, resourceName, string(input))
+		}
+		return value, nil
+	}
+
+	// case 2: measured resources represent quota as a string of value with unit
+	var value string
+	err := json.Unmarshal([]byte(input), &value)
+	if err != nil {
+		return 0, fmt.Errorf("expected string field for %s/%s, but got %q", serviceType, resourceName, string(input))
+	}
+	parsedValue, err := unit.Parse(value)
+	if err != nil {
+		return 0, fmt.Errorf("in value for %s/%s: %w", serviceType, resourceName, err)
+	}
+	return parsedValue, nil
+}

--- a/limes/resources/overrides_test.go
+++ b/limes/resources/overrides_test.go
@@ -1,0 +1,125 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package limesresources
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/sapcc/go-api-declarations/limes"
+)
+
+func TestParseQuotaOverrides(t *testing.T) {
+	// mock implementation of getUnit callback presenting two example resources
+	getUnit := func(serviceType limes.ServiceType, resourceName ResourceName) (limes.Unit, error) {
+		switch fmt.Sprintf("%s/%s", serviceType, resourceName) {
+		case "unittest/capacity":
+			return limes.UnitBytes, nil
+		case "unittest/things":
+			return limes.UnitNone, nil
+		default:
+			return limes.UnitUnspecified, fmt.Errorf("%s/%s is not a valid resource", serviceType, resourceName)
+		}
+	}
+
+	// test successful parsing
+	buf := []byte(`
+		{
+			"domain-one": {
+				"project-one": {
+					"unittest": {
+						"things": 20,
+						"capacity": "5 GiB"
+					}
+				}
+			}
+		}
+	`)
+	result, errs := ParseQuotaOverrides(buf, getUnit)
+	assertDeepEqual(t, "errors", errorsToStrings(errs), []string{})
+	assertDeepEqual(t, "result", result, map[string]map[string]map[limes.ServiceType]map[ResourceName]uint64{
+		"domain-one": {
+			"project-one": {
+				"unittest": {
+					"things":   20,
+					"capacity": 5 << 30, // capacity is in unit "B"
+				},
+			},
+		},
+	})
+
+	// test parsing errors
+	buf = []byte(`
+		{
+			"domain-one": {
+				"project1": {
+					"unittest": {
+						"capacity": [ 1, "GiB" ]
+					}
+				},
+				"project2": {
+					"unittest": {
+						"things": "50 GiB"
+					}
+				},
+				"project3": {
+					"unittest": {
+						"unknown-resource": 10
+					}
+				},
+				"project4": {
+					"unknown-service": {
+						"items": 10
+					}
+				}
+			}
+		}
+	`)
+	buf = bytes.ReplaceAll(buf, []byte("\t"), []byte("  "))
+	_, errs = ParseQuotaOverrides(buf, getUnit)
+	assertDeepEqual(t, "errors", errorsToStrings(errs), []string{
+		`expected string field for unittest/capacity, but got "[ 1, \"GiB\" ]"`,
+		`expected uint64 value for unittest/things, but got "\"50 GiB\""`,
+		`unittest/unknown-resource is not a valid resource`,
+		`unknown-service/items is not a valid resource`,
+	})
+}
+
+func errorsToStrings(errs []error) []string {
+	result := make([]string, len(errs))
+	for idx, err := range errs {
+		result[idx] = err.Error()
+	}
+	sort.Strings(result) // map iteration order in ParseQuotaOverrides() is not deterministic
+	return result
+}
+
+// Like assert.DeepEqual() from go-bits, which we cannot depend on because that would be a cyclic dependency.
+func assertDeepEqual(t *testing.T, msg string, actual, expected any) {
+	t.Helper()
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("failed assertion for %s", msg)
+		t.Logf("expected = %#v", expected)
+		t.Logf("  actual = %#v", actual)
+	}
+}


### PR DESCRIPTION
I want to reuse this in limesctl for CI-level validation of quota-overrides.json files.

This slightly differs from [the existing implementation in Limes core](https://github.com/sapcc/limes/blob/753afb2a34a9fab1cc970cf373acb7c0c2f57f43/internal/core/cluster.go#L183-L236):
- To uncouple from the `core.Cluster` structure, this uses a callback to learn about which resources exist and which units they use.
- I also used the opportunity to refactor out the innermost loop into a helper function for readability.
- Because this is below go-bits, any go-bits APIs were replaced by their std equivalents (in the case of `errext.ErrorSet -> []error`) or replaced with a simple inline implementation (in the case of `assert.DeepEqual`).