### PR TITLE
Add historical usage to AZ report

### DIFF
--- a/limes/resources/report_project.go
+++ b/limes/resources/report_project.go
@@ -76,8 +76,8 @@ type ProjectAZResourceReport struct {
 }
 
 type HistoricalReport struct {
-	MinUsage uint64 `json:"min_usage,omitempty"`
-	MaxUsage uint64 `json:"max_usage,omitempty"`
+	MinUsage uint64             `json:"min_usage,omitempty"`
+	MaxUsage uint64             `json:"max_usage,omitempty"`
 	Duration CommitmentDuration `json:"duration,omitempty"`
 }
 

--- a/limes/resources/report_project.go
+++ b/limes/resources/report_project.go
@@ -78,7 +78,7 @@ type ProjectAZResourceReport struct {
 type HistoricalReport struct {
 	MinUsage uint64 `json:"min_usage,omitempty"`
 	MaxUsage uint64 `json:"max_usage,omitempty"`
-	Duration string `json:"duration,omitempty"`
+	Duration CommitmentDuration `json:"duration,omitempty"`
 }
 
 // ProjectServiceReports provides fast lookup of services using a map, but serializes

--- a/limes/resources/report_project.go
+++ b/limes/resources/report_project.go
@@ -71,8 +71,8 @@ type ProjectAZResourceReport struct {
 	PlannedCommitments map[string]uint64 `json:"planned_commitments,omitempty"`
 	Usage              uint64            `json:"usage"`
 	PhysicalUsage      *uint64           `json:"physical_usage,omitempty"`
-	MinHistoricalUsage string            `json:"min_historical_usage,omitempty"`
-	MaxHistorcialUsage string            `json:"max_historical_usage,omitempty"`
+	MinHistoricalUsage uint64            `json:"min_historical_usage,omitempty"`
+	MaxHistorcialUsage uint64            `json:"max_historical_usage,omitempty"`
 	Subresources       json.RawMessage   `json:"subresources,omitempty"`
 }
 

--- a/limes/resources/report_project.go
+++ b/limes/resources/report_project.go
@@ -71,7 +71,8 @@ type ProjectAZResourceReport struct {
 	PlannedCommitments map[string]uint64 `json:"planned_commitments,omitempty"`
 	Usage              uint64            `json:"usage"`
 	PhysicalUsage      *uint64           `json:"physical_usage,omitempty"`
-	HistoricalUsage    string            `json:"historical_usage,omitempty"`
+	MinHistoricalUsage string            `json:"min_historical_usage,omitempty"`
+	MaxHistorcialUsage string            `json:"max_historical_usage,omitempty"`
 	Subresources       json.RawMessage   `json:"subresources,omitempty"`
 }
 

--- a/limes/resources/report_project.go
+++ b/limes/resources/report_project.go
@@ -71,6 +71,7 @@ type ProjectAZResourceReport struct {
 	PlannedCommitments map[string]uint64 `json:"planned_commitments,omitempty"`
 	Usage              uint64            `json:"usage"`
 	PhysicalUsage      *uint64           `json:"physical_usage,omitempty"`
+	HistoricalUsage    string            `json:"historical_usage,omitempty"`
 	Subresources       json.RawMessage   `json:"subresources,omitempty"`
 }
 

--- a/limes/resources/report_project.go
+++ b/limes/resources/report_project.go
@@ -71,9 +71,14 @@ type ProjectAZResourceReport struct {
 	PlannedCommitments map[string]uint64 `json:"planned_commitments,omitempty"`
 	Usage              uint64            `json:"usage"`
 	PhysicalUsage      *uint64           `json:"physical_usage,omitempty"`
-	MinHistoricalUsage uint64            `json:"min_historical_usage,omitempty"`
-	MaxHistorcialUsage uint64            `json:"max_historical_usage,omitempty"`
+	HistoricalUsage    *HistoricalReport `json:"historical_usage,omitempty"`
 	Subresources       json.RawMessage   `json:"subresources,omitempty"`
+}
+
+type HistoricalReport struct {
+	MinUsage uint64 `json:"min_usage,omitempty"`
+	MaxUsage uint64 `json:"max_usage,omitempty"`
+	Duration string `json:"duration,omitempty"`
 }
 
 // ProjectServiceReports provides fast lookup of services using a map, but serializes


### PR DESCRIPTION
I'm torn what's better, either add the atribute to the API declaration or wrap the historical_usage in another struct on the API side. I think this approach is cleaner.
If this approach is agreeable, then I will push a new tag `v1.11.3` and update the vendor on the limes repo.