### PR TITLE
add spec and types for LIQUID

### DIFF
--- a/limes/metadata.go
+++ b/limes/metadata.go
@@ -19,6 +19,8 @@
 
 package limes
 
+import "github.com/sapcc/go-api-declarations/liquid"
+
 // ClusterInfo contains the metadata for a cluster that appears in both
 // resource data and rate data reports.
 type ClusterInfo struct {
@@ -61,12 +63,12 @@ type ServiceInfo struct {
 }
 
 // AvailabilityZone is the name of an availability zone.
-// Some special values are enumerated below.
-type AvailabilityZone string
+// Some special values are enumerated at the original declaration site.
+type AvailabilityZone = liquid.AvailabilityZone
 
 const (
 	// AvailabilityZoneAny marks values that are not bound to a specific AZ.
-	AvailabilityZoneAny AvailabilityZone = "any"
+	AvailabilityZoneAny AvailabilityZone = liquid.AvailabilityZoneAny
 	// AvailabilityZoneUnknown marks values that are bound to an unknown AZ.
-	AvailabilityZoneUnknown AvailabilityZone = "unknown"
+	AvailabilityZoneUnknown AvailabilityZone = liquid.AvailabilityZoneUnknown
 )

--- a/limes/resources/metadata.go
+++ b/limes/resources/metadata.go
@@ -21,11 +21,12 @@ package limesresources
 
 import (
 	"github.com/sapcc/go-api-declarations/limes"
+	"github.com/sapcc/go-api-declarations/liquid"
 )
 
 // ResourceName identifies a resource within a service. This type is used to distinguish
 // resource names from other types of string values in function signatures.
-type ResourceName string
+type ResourceName = liquid.ResourceName
 
 // ResourceInfo contains the metadata for a resource (i.e. some thing for which
 // quota and usage values can be retrieved from a backend service).

--- a/limes/resources/overrides.go
+++ b/limes/resources/overrides.go
@@ -82,7 +82,7 @@ func parseSingleQuotaOverrideValue(input json.RawMessage, serviceType limes.Serv
 	if err != nil {
 		return 0, fmt.Errorf("expected string field for %s/%s, but got %q", serviceType, resourceName, string(input))
 	}
-	parsedValue, err := unit.Parse(value)
+	parsedValue, err := limes.ParseInUnit(unit, value)
 	if err != nil {
 		return 0, fmt.Errorf("in value for %s/%s: %w", serviceType, resourceName, err)
 	}

--- a/limes/unit.go
+++ b/limes/unit.go
@@ -23,93 +23,36 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/sapcc/go-api-declarations/liquid"
 )
 
 // Unit enumerates allowed values for the unit a resource's quota/usage is
 // measured in.
-type Unit string
+type Unit = liquid.Unit
 
 const (
-	// UnitNone is used for countable (rather than measurable) resources.
-	UnitNone Unit = ""
-	// UnitBytes is exactly that.
-	UnitBytes Unit = "B"
-	// UnitKibibytes is exactly that.
-	UnitKibibytes Unit = "KiB"
-	// UnitMebibytes is exactly that.
-	UnitMebibytes Unit = "MiB"
-	// UnitGibibytes is exactly that.
-	UnitGibibytes Unit = "GiB"
-	// UnitTebibytes is exactly that.
-	UnitTebibytes Unit = "TiB"
-	// UnitPebibytes is exactly that.
-	UnitPebibytes Unit = "PiB"
-	// UnitExbibytes is exactly that.
-	UnitExbibytes Unit = "EiB"
-	// UnitUnspecified is used as a placeholder when the unit is not known.
-	UnitUnspecified Unit = "UNSPECIFIED"
+	UnitNone        Unit = liquid.UnitNone
+	UnitBytes       Unit = liquid.UnitBytes
+	UnitKibibytes   Unit = liquid.UnitKibibytes
+	UnitMebibytes   Unit = liquid.UnitMebibytes
+	UnitGibibytes   Unit = liquid.UnitGibibytes
+	UnitTebibytes   Unit = liquid.UnitTebibytes
+	UnitPebibytes   Unit = liquid.UnitPebibytes
+	UnitExbibytes   Unit = liquid.UnitExbibytes
+	UnitUnspecified Unit = liquid.UnitUnspecified
 )
 
-var allValidUnits = []Unit{
-	UnitNone,
-	UnitBytes,
-	UnitKibibytes,
-	UnitMebibytes,
-	UnitGibibytes,
-	UnitTebibytes,
-	UnitPebibytes,
-	UnitExbibytes,
-}
-
-// UnmarshalYAML implements the yaml.Unmarshaler interface. This method validates
-// that units in the config file actually exist.
-func (u *Unit) UnmarshalYAML(unmarshal func(any) error) error {
-	var s string
-	err := unmarshal(&s)
-	if err != nil {
-		return err
-	}
-	for _, unit := range allValidUnits {
-		if string(unit) == s {
-			*u = unit
-			return nil
-		}
-	}
-	return fmt.Errorf("unknown unit: %q", s)
-}
-
-// Base returns the base unit of this unit. For units defined as a multiple of
-// another unit, that unit is the base unit. Otherwise, the same unit and a
-// multiple of 1 is returned.
-func (u Unit) Base() (Unit, uint64) { //nolint:gocritic // not necessary to name the results
-	switch u {
-	case UnitKibibytes:
-		return UnitBytes, 1 << 10
-	case UnitMebibytes:
-		return UnitBytes, 1 << 20
-	case UnitGibibytes:
-		return UnitBytes, 1 << 30
-	case UnitTebibytes:
-		return UnitBytes, 1 << 40
-	case UnitPebibytes:
-		return UnitBytes, 1 << 50
-	case UnitExbibytes:
-		return UnitBytes, 1 << 60
-	default:
-		return u, 1
-	}
-}
-
-// Parse parses the string representation of a value with this unit (or any unit
-// that can be converted to it).
+// ParseInUnit parses the string representation of a value with this unit
+// (or any unit that can be converted to it).
 //
-//	UnitMebibytes.Parse("10 MiB") -> 10
-//	UnitMebibytes.Parse("10 GiB") -> 10240
-//	UnitMebibytes.Parse("10 KiB") -> returns FractionalValueError
-//	UnitMebibytes.Parse("10")     -> returns syntax error (missing unit)
-//	UnitNone.Parse("42")          -> 42
-//	UnitNone.Parse("42 MiB")      -> returns syntax error (unexpected unit)
-func (u Unit) Parse(str string) (uint64, error) {
+//	ParseInUnit(UnitMebibytes, "10 MiB") -> 10
+//	ParseInUnit(UnitMebibytes, "10 GiB") -> 10240
+//	ParseInUnit(UnitMebibytes, "10 KiB") -> returns FractionalValueError
+//	ParseInUnit(UnitMebibytes, "10")     -> returns syntax error (missing unit)
+//	ParseInUnit(UnitNone, "42")          -> 42
+//	ParseInUnit(UnitNone, "42 MiB")      -> returns syntax error (unexpected unit)
+func ParseInUnit(u Unit, str string) (uint64, error) {
 	// for countable resources, expect a number only
 	if u == UnitNone {
 		return strconv.ParseUint(strings.TrimSpace(str), 10, 64)
@@ -188,8 +131,8 @@ type IncompatibleUnitsError struct {
 
 // Error implements the error interface.
 func (e IncompatibleUnitsError) Error() string {
-	return "cannot convert value from " + e.Source.toStringForError() +
-		" to " + e.Target.toStringForError() +
+	return "cannot convert value from " + toStringForError(e.Source) +
+		" to " + toStringForError(e.Target) +
 		" because units are incompatible"
 }
 
@@ -207,7 +150,7 @@ func (e FractionalValueError) Error() string {
 	)
 }
 
-func (u Unit) toStringForError() string {
+func toStringForError(u Unit) string {
 	if string(u) == "" {
 		return "<count>"
 	}

--- a/liquid/availability_zone.go
+++ b/liquid/availability_zone.go
@@ -1,0 +1,37 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package liquid
+
+// AvailabilityZone is the name of an availability zone.
+// Some special values are enumerated below.
+type AvailabilityZone string
+
+const (
+	// AvailabilityZoneAny marks values that are not bound to a specific AZ.
+	AvailabilityZoneAny AvailabilityZone = "any"
+	// AvailabilityZoneUnknown marks values that are bound to an unknown AZ.
+	AvailabilityZoneUnknown AvailabilityZone = "unknown"
+)
+
+// InAnyAZ is a convenience constructor for the PerAZ fields of ResourceCapacityReport and ResourceUsageReport.
+// It can be used for non-AZ-aware resources. The provided report will be placed under the AvailabilityZoneAny key.
+func InAnyAZ[T any](value T) map[AvailabilityZone]*T {
+	return map[AvailabilityZone]*T{AvailabilityZoneAny: &value}
+}

--- a/liquid/doc.go
+++ b/liquid/doc.go
@@ -1,0 +1,120 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+// Package liquid contains the API specification for LIQUID (the [Limes] Interface for Quota and Usage Interrogation and Discovery).
+//
+// [Limes] expects OpenStack services to expose this interface either natively or through an adapter.
+// The interface allows Limes to retrieve quota and usage data, and optionally capacity data, from the respective OpenStack service.
+// Limes will also use the interface to set quota within the service.
+//
+// # Naming conventions
+//
+// Throughout this document:
+//   - "LIQUID" (upper case) refers to the REST interface defined by this document.
+//   - "A liquid" (lower case) refers to a server implementing LIQUID.
+//   - "The liquid's service" refers to the OpenStack service that the liquid is a part of or connected to.
+//
+// Each liquid provides access to one or more resources.
+// A resource is any countable or measurable kind of entity managed by the liquid's service.
+//
+// Limes discovers liquids through the Keystone service catalog.
+// Each liquid should be registered there with a service type that has the prefix "liquid-".
+// If a liquid uses vendor-specific APIs to interact with its service, its service type should include the vendor name.
+//
+// # Inside a resource: Usage, quota, capacity, overcommit
+//
+// All resources report a usage value for each Keystone project.
+// This describes how much of the resource is used by objects created within the project.
+// For example, the usage for the compute resource "cores" is the sum of all vCPUs allocated to each VM in that project.
+//
+// Some resources maintain a quota value for each Keystone project.
+// If so, the usage value must be meaningfully connected to the quota value:
+// Provisioning of new assets shall be rejected with "quota exceeded" if and only if usage would exceed quota afterwards.
+//
+// Some resources report a capacity value that applies to the entire OpenStack deployment.
+// For example, the capacity for the compute resource "cores" would be the total amount of CPU cores available across all hypervisors.
+//
+// This capacity value, as it is reported by the liquid, is also called "raw capacity".
+// Limes may be configured to apply an "overcommit factor" to obtain an "effective capacity".
+// For example, the compute resource "cores" is often overcommitted because most users do not put 100% load on their VMs all the time.
+// In this case, quota and usage values are in terms of effective capacity, even though the capacity value is in terms of raw capacity.
+//
+// Capacity and usage may be AZ-aware, in which case one value will be reported per availability zone (AZ).
+// Quota is not modelled as AZ-aware since there are no OpenStack services that support AZ-aware quota at this time.
+//
+// # Structure
+//
+// LIQUID is structured as a REST-like HTTP API akin to those of the various OpenStack services.
+// Like with any other OpenStack API, the client (i.e. Limes) authenticates to the liquid by providing its Keystone token in the HTTP header "X-Auth-Token".
+//
+// Each individual endpoint is documented in a section of this docstring whose title starts with "Endpoint:".
+// Unless noted otherwise, a liquid must implement all documented endpoints.
+// The full URL of the endpoint is obtained by appending the subpath from the section header to the liquid's base URL from the Keystone service catalog.
+//
+// The documentation for an endpoint may refer to a request body being expected or a response body being generated on success.
+// In all such cases, the request or response body will be encoded as "Content-Type: application/json".
+// The structure of the payload must conform to the referenced Go type.
+//
+// When producing a successful response, the status code shall be 200 (OK) unless noted otherwise.
+// When producing an error response (with a status code between 400 and 599), the liquid shall include a response body of "Content-Type: text/plain" to indicate the error.
+//
+// # Metrics
+//
+// While measuring quota, usage and capacity on behalf of Limes, liquids may obtain other metrics that may be useful to report to the OpenStack operator.
+// LIQUID offers a facility to report metrics like this to Limes as part of the regular quota/usage and capacity reports.
+// These metrics will be stored in the Limes database and then collectively forwarded to a metrics database like [Prometheus].
+// This delivery method is designed to ensure that liquids can be operated without their own persistent storage.
+//
+// LIQUID structures metrics in the same way as the [OpenMetrics format] used by Prometheus:
+//   - A "metric" is a floating-point-valued measurement with an optional set of labels. A label set is a map of string keys to string values.
+//   - A "metric family" is a named set of metrics where the labelset of each metric must have the same keys, but a distinct set of values.
+//
+// # Endpoint: GET /v1/info
+//
+// Returns information about the OpenStack service and the resources available within it.
+//   - On success, the response body payload must be of type ServiceInfo.
+//
+// # Endpoint: POST /v1/report-capacity
+//
+// Reports available capacity across all resources of this service.
+//   - The request body payload must be of type ServiceCapacityRequest.
+//   - On success, the response body payload must be of type ServiceCapacityReport.
+//
+// # Endpoint: POST /v1/projects/:uuid/report-usage
+//
+// Reports usage data (as well as applicable quotas) within a project across all resources of this service.
+//   - The ":uuid" parameter in the request path must refer to a project ID known to Keystone.
+//   - The request body payload must be of type ServiceUsageRequest.
+//   - On success, the response body payload must be of type ServiceUsageReport.
+//
+// # Endpoint: PUT /v1/projects/:uuid/quota
+//
+// Updates quota within a project across all resources of this service.
+//   - The ":uuid" parameter in the request path must refer to a project ID known to Keystone.
+//   - The request body payload must be of type ServiceQuotaRequest.
+//   - On success, the response body shall be empty and status 204 (No Content) shall be returned.
+//
+// [Limes]: https://github.com/sapcc/limes
+// [OpenMetrics format]: https://github.com/OpenObservability/OpenMetrics/blob/master/specification/OpenMetrics.md
+// [Prometheus]: https://prometheus.io/
+package liquid
+
+// ResourceName identifies a resource within a service. This type is used to distinguish
+// resource names from other types of string values in function signatures.
+type ResourceName string

--- a/liquid/info.go
+++ b/liquid/info.go
@@ -1,0 +1,65 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package liquid
+
+// ServiceInfo is the response payload format for GET /v1/info.
+type ServiceInfo struct {
+	// This version number shall be increased whenever any part of the ServiceInfo changes.
+	//
+	// The metadata version is also reported on most other API responses.
+	// Limes uses this version number to discover when the metadata has changed and needs to be queried again.
+	//
+	// There is no prescribed semantics to the value of the version number, except that:
+	//   - Changes in ServiceInfo must lead to a monotonic increase of the Version.
+	//   - If the contents of ServiceInfo do not change, the Version too shall not change.
+	//
+	// Our recommendation is to use the UNIX timestamp of the most recent change.
+	// If you run multiple replicas of the liquid, take care to ensure that they agree on the Version value.
+	Version int64 `json:"version"`
+
+	// Info for each resource that this service provides.
+	Resources map[ResourceName]ResourceInfo `json:"resources"`
+
+	// Info for each metric family that is included in a response to a query for cluster capacity.
+	CapacityMetricFamilies map[MetricName]MetricFamilyInfo `json:"capacityMetricFamilies"`
+
+	// Info for each metric family that is included in a response to a query for project quota and usage.
+	UsageMetricFamilies map[MetricName]MetricFamilyInfo `json:"usageMetricFamilies"`
+}
+
+// ResourceInfo describes a resource that a liquid's service provides.
+// This type appears in type ServiceInfo.
+type ResourceInfo struct {
+	// If omitted or empty, the resource is "countable" and any quota or usage values describe a number of objects.
+	// If non-empty, the resource is "measured" and quota or usage values are measured in the given unit.
+	// For example, the compute resource "cores" is countable, but the compute resource "ram" is measured, usually in MiB.
+	Unit Unit `json:"unit,omitempty"`
+
+	// Whether the liquid reports capacity for this resource on the cluster level.
+	HasCapacity bool `json:"hasCapacity"`
+
+	// Whether Limes needs to include demand statistics for this resource in its requests for a capacity report.
+	NeedsResourceDemand bool `json:"needsResourceDemand"`
+
+	// Whether the liquid reports quota for this resource on the project level.
+	// If false, only usage is reported on the project level.
+	// Limes will abstain from maintaining quota on such resources.
+	HasQuota bool `json:"hasQuota"`
+}

--- a/liquid/metrics.go
+++ b/liquid/metrics.go
@@ -1,0 +1,70 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package liquid
+
+// MetricName is the name of a metric family.
+// For more information, please refer to the "Metrics" section of the package documentation.
+type MetricName string
+
+// MetricType is an enum.
+// For more information, please refer to the "Metrics" section of the package documentation.
+type MetricType string
+
+const (
+	MetricTypeUnknown        MetricType = "unknown"
+	MetricTypeGauge          MetricType = "gauge"
+	MetricTypeCounter        MetricType = "counter"
+	MetricTypeStateset       MetricType = "stateset"
+	MetricTypeInfo           MetricType = "info"
+	MetricTypeHistogram      MetricType = "histogram"
+	MetricTypeGaugeHistogram MetricType = "gaugehistogram"
+	MetricTypeSummary        MetricType = "summary"
+)
+
+// MetricFamilyInfo describes a metric family.
+// This type appears in type ServiceInfo.
+// For more information, please refer to the "Metrics" section of the package documentation.
+type MetricFamilyInfo struct {
+	// The metric type.
+	// The most common values are MetricTypeGauge and MetricTypeCounter.
+	Type MetricType `json:"type"`
+
+	// A brief description of the metric family for human consumption.
+	// Should be short enough to be used as a tooltip.
+	Help string `json:"help"`
+
+	// All labels that will be present on each metric in this family.
+	LabelKeys []string `json:"labelKeys"`
+}
+
+// Metric is a metric.
+// This type appears in type ServiceCapacityReport.
+// For more information, please refer to the "Metrics" section of the package documentation.
+//
+// Because reports can include very large numbers of Metric instances, this type uses a compact serialization to improve efficiency.
+type Metric struct {
+	Value float64 `json:"v"`
+
+	// This label set does not include keys to avoid redundant encoding.
+	// The slice must be of the same length as the LabelKeys slice in the respective MetricFamilyInfo instance in type ServiceInfo.
+	// Each label value is implied to belong to the label key with the same slice index.
+	// For example, LabelKeys = ["name","location"] and LabelValues = ["author","work"] represents the label set {name="author",location="work"}.
+	LabelValues []string `json:"l"`
+}

--- a/liquid/overcommit_factor.go
+++ b/liquid/overcommit_factor.go
@@ -1,0 +1,59 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package liquid
+
+// OvercommitFactor is the ratio between raw and effective capacity of a resource.
+// It appears in type ResourceDemand.
+//
+// In its methods, the zero value behaves as 1, meaning that no overcommit is taking place.
+type OvercommitFactor float64
+
+// ApplyTo converts a raw capacity into an effective capacity.
+func (f OvercommitFactor) ApplyTo(rawCapacity uint64) uint64 {
+	if f == 0 {
+		// if no overcommit was configured, assume an overcommit factor of 1
+		return rawCapacity
+	}
+	return uint64(float64(rawCapacity) * float64(f))
+}
+
+// ApplyInReverseTo turns the given effective capacity back into a raw capacity.
+func (f OvercommitFactor) ApplyInReverseTo(capacity uint64) uint64 {
+	if f == 0 {
+		// if no overcommit was configured, assume an overcommit factor of 1
+		return capacity
+	}
+	rawCapacity := uint64(float64(capacity) / float64(f))
+	for f.ApplyTo(rawCapacity) < capacity {
+		// fix errors from rounding down float64 -> uint64 above
+		rawCapacity++
+	}
+	return rawCapacity
+}
+
+// ApplyInReverseToDemand is a shorthand for calling ApplyInReverseTo() on all fields of a ResourceDemand,
+// thus turning all values initially given in terms of effective capacity into the corresponding raw capacity.
+func (f OvercommitFactor) ApplyInReverseToDemand(demand ResourceDemandInAZ) ResourceDemandInAZ {
+	return ResourceDemandInAZ{
+		Usage:              f.ApplyInReverseTo(demand.Usage),
+		UnusedCommitments:  f.ApplyInReverseTo(demand.UnusedCommitments),
+		PendingCommitments: f.ApplyInReverseTo(demand.PendingCommitments),
+	}
+}

--- a/liquid/overcommit_factor_test.go
+++ b/liquid/overcommit_factor_test.go
@@ -1,0 +1,46 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package liquid
+
+import "testing"
+
+func TestOvercommitFactor(t *testing.T) {
+	check := func(f OvercommitFactor, raw, effective uint64) {
+		actualEffective := f.ApplyTo(raw)
+		if actualEffective != effective {
+			t.Errorf("expected (%g).ApplyTo(%d) = %d, but got %d", f, raw, effective, actualEffective)
+		}
+		actualRaw := f.ApplyInReverseTo(effective)
+		if actualRaw != raw {
+			t.Errorf("expected (%g).ApplyInReverseTo(%d) = %d, but got %d", f, effective, raw, actualRaw)
+		}
+	}
+
+	check(0, 42, 42)
+	check(1, 42, 42)
+	check(1.2, 42, 50)
+
+	// ApplyTo is pretty straightforward, but I'd like some more test coverage for ApplyInReverseTo
+	for _, factor := range []OvercommitFactor{0, 1, 1.1, 1.2, 1.5, 2, 2.5, 3, 4} {
+		for raw := uint64(0); raw <= 100; raw++ {
+			check(factor, raw, factor.ApplyTo(raw))
+		}
+	}
+}

--- a/liquid/quota.go
+++ b/liquid/quota.go
@@ -1,0 +1,35 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package liquid
+
+// ServiceQuotaRequest is the request payload format for PUT /v1/projects/:uuid/quota.
+type ServiceQuotaRequest struct {
+	Resources map[ResourceName]ResourceQuotaRequest `json:"resources"`
+}
+
+// ResourceQuotaRequest contains the new quota value for a single resource.
+// It appears in type ServiceQuotaRequest.
+type ResourceQuotaRequest struct {
+	Quota uint64 `json:"quota"`
+
+	// This struct looks superfluous (why not just have a bare uint64?), but in
+	// the unlikely event that AZ-aware quota may be added in the future, having
+	// this struct allows for that to be a backwards-compatible change.
+}

--- a/liquid/report_capacity.go
+++ b/liquid/report_capacity.go
@@ -1,0 +1,103 @@
+/******************************************************************************
+*
+*  Copyright 2024 SAP SE
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+******************************************************************************/
+
+package liquid
+
+// ServiceCapacityRequest is the request payload format for POST /v1/report-capacity.
+type ServiceCapacityRequest struct {
+	// All AZs known to Limes.
+	// Many liquids need this information to ensure that:
+	//   - AZ-aware capacity is reported for all known AZs, and
+	//   - capacity belonging to an invalid AZ is grouped into AvailabilityZoneUnknown.
+	// Limes provides this list here to reduce the number of places where this information needs to be maintained manually.
+	AllAZs []AvailabilityZone `json:"allAZs"`
+
+	// Must contain an entry for each resource that was declared in type ServiceInfo with "NeedsResourceDemand = true".
+	DemandByResource map[ResourceName]ResourceDemand `json:"demandByResource"`
+}
+
+// ResourceDemand contains demand statistics for a resource.
+// It appears in type ServiceCapacityRequest.
+//
+// This is used when a liquid needs to be able to reshuffle capacity between different resources based on actual user demand.
+type ResourceDemand struct {
+	// Demand values are provided in terms of effective capacity.
+	// This factor can be applied to them in reverse to obtain values in terms of raw capacity.
+	OvercommitFactor OvercommitFactor `json:"overcommitFactor,omitempty"`
+
+	// The actual demand values are AZ-aware.
+	// For non-AZ-aware resources, the only entry will be for AvailabilityZoneAny.
+	PerAZ map[AvailabilityZone]ResourceDemandInAZ `json:"perAZ"`
+}
+
+// ResourceDemandInAZ contains demand statistics for a resource in a single AZ.
+// It appears in type ResourceDemand.
+//
+// The fields are ordered in descending priority.
+// All values are in terms of effective capacity, and are sums over all OpenStack projects.
+type ResourceDemandInAZ struct {
+	// Usage counts all existing usage.
+	Usage uint64 `json:"usage"`
+
+	// UnusedCommitments counts all commitments that are confirmed but not covered by existing usage.
+	UnusedCommitments uint64 `json:"unusedCommitments"`
+
+	// PendingCommitments counts all commitments that should be confirmed by now, but are not.
+	PendingCommitments uint64 `json:"pendingCommitments"`
+}
+
+// ServiceCapacityReport is the response payload format for POST /v1/report-capacity.
+type ServiceCapacityReport struct {
+	// The same version number that is reported in the Version field of a GET /v1/info response.
+	// This is used to signal to Limes to refetch GET /v1/info after configuration changes.
+	InfoVersion int64 `json:"infoVersion"`
+
+	// Must contain an entry for each resource that was declared in type ServiceInfo with "HasCapacity = true".
+	Resources map[ResourceName]*ResourceCapacityReport `json:"resources"`
+
+	// Must contain an entry for each metric family that was declared for capacity metrics in type ServiceInfo.
+	Metrics map[MetricName][]Metric `json:"metrics"`
+}
+
+// ResourceCapacityReport contains capacity data for a resource.
+// It appears in type ServiceCapacityReport.
+type ResourceCapacityReport struct {
+	// For non-AZ-aware resources, the only entry shall be for AvailabilityZoneAny.
+	// Use func InAnyAZ to quickly construct a suitable structure.
+	//
+	// For AZ-aware resources, there shall be an entry for each AZ mentioned in ServiceCapacityRequest.AllAZs.
+	// Reports for AZ-aware resources may also include an entry for AvailabilityZoneUnknown as needed.
+	PerAZ map[AvailabilityZone]*AZResourceCapacityReport `json:"perAZ"`
+}
+
+// AZResourceCapacityReport contains capacity data for a resource in a single AZ.
+// It appears in type ResourceCapacityReport.
+type AZResourceCapacityReport struct {
+	Capacity uint64 `json:"capacity"`
+
+	// How much of the Capacity is used, or null if no usage data is available.
+	//
+	// This should only be reported if the service has an efficient way to obtain this number from the backend.
+	// If you can only fill this by summing up usage across all projects, don't; Limes can already do that.
+	// This is intended for consistency checks and to estimate how much usage cannot be attributed to OpenStack projects.
+	// For example, for compute, this would allow estimating how many VMs are not managed by Nova.
+	Usage *uint64 `json:"usage,omitempty"`
+
+	// Only filled if the resource is able to report subcapacities in a useful way.
+	Subcapacities []Subcapacity `json:"subcapacities,omitempty"`
+}

--- a/liquid/report_usage.go
+++ b/liquid/report_usage.go
@@ -1,0 +1,120 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package liquid
+
+// ServiceUsageRequest is the request payload format for POST /v1/projects/:uuid/report-usage.
+type ServiceUsageRequest struct {
+	// All AZs known to Limes.
+	// Many liquids need this information to ensure that:
+	//   - AZ-aware usage is reported for all known AZs, and
+	//   - usage belonging to an invalid AZ is grouped into AvailabilityZoneUnknown.
+	// Limes provides this list here to reduce the number of places where this information needs to be maintained manually.
+	AllAZs []AvailabilityZone `json:"allAZs"`
+}
+
+// ServiceUsageReport is the response payload format for POST /v1/projects/:uuid/report-usage.
+type ServiceUsageReport struct {
+	// The same version number that is reported in the Version field of a GET /v1/info response.
+	// This is used to signal to Limes to refetch GET /v1/info after configuration changes.
+	InfoVersion int64 `json:"infoVersion"`
+
+	// Must contain an entry for each resource that was declared in type ServiceInfo.
+	Resources map[ResourceName]*ResourceUsageReport `json:"resources"`
+
+	// Must contain an entry for each metric family that was declared for usage metrics in type ServiceInfo.
+	Metrics map[MetricName][]Metric `json:"metrics"`
+}
+
+// ResourceUsageReport contains usage data for a resource in a single project.
+// It appears in type ServiceUsageReport.
+type ResourceUsageReport struct {
+	// If true, this project is forbidden from accessing this resource.
+	// This has two consequences:
+	//   - If the resource has quota, Limes will never try to assign quota for this resource to this project.
+	//   - If the project has no usage in this resource, Limes will hide this resource from project reports.
+	Forbidden bool `json:"forbidden"`
+
+	// This shall be null if and only if the resource is declared with "HasQuota = false".
+	// A negative value, usually -1, indicates "infinite quota" (i.e., the absence of a quota).
+	Quota *int64 `json:"quota,omitempty"`
+
+	// For non-AZ-aware resources, the only entry shall be for AvailabilityZoneAny.
+	// Use func InAnyAZ to quickly construct a suitable structure.
+	//
+	// For AZ-aware resources, there shall be an entry for each AZ mentioned in ServiceUsageRequest.AllAZs.
+	// Reports for AZ-aware resources may also include an entry for AvailabilityZoneUnknown as needed.
+	// When starting from a non-AZ-aware usage number that is later broken down with AZ-aware data, use func PrepareForBreakdownInto.
+	PerAZ map[AvailabilityZone]*AZResourceUsageReport `json:"perAZ"`
+}
+
+// AZResourceUsageReport contains usage data for a resource in a single project and AZ.
+// It appears in type ResourceUsageReport.
+type AZResourceUsageReport struct {
+	// The amount of usage for this resource.
+	Usage uint64 `json:"usage"`
+
+	// The amount of physical usage for this resource.
+	// Only reported if this notion makes sense for the particular resource.
+	//
+	// For example, consider the Manila resource "share_capacity".
+	// If a project has 5 shares, each with 10 GiB size and each containing 1 GiB data, then Usage = 50 GiB and PhysicalUsage = 5 GiB.
+	// It is not allowed to report 5 GiB as Usage in this situation, since the 50 GiB value is used when judging whether the Quota fits.
+	PhysicalUsage *uint64 `json:"physicalUsage,omitempty"`
+
+	// Only filled if the resource is able to report subresources for this usage in a useful way.
+	Subresources []Subresource `json:"subresources,omitempty"`
+}
+
+// PrepareForBreakdownInto is a convenience constructor for the PerAZ field of ResourceUsageReport.
+// It builds a map with zero-valued entries for all of the named AZs.
+// Furthermore, if the provided AZ report contains nonzero usage, it is placed in the AvailabilityZoneUnknown key.
+//
+// This constructor can be used when the total usage data is reported without AZ awareness.
+// An AZ breakdown can later be added with the AddLocalizedUsage() method of ResourceUsageReport.
+func (r AZResourceUsageReport) PrepareForBreakdownInto(allAZs []AvailabilityZone) map[AvailabilityZone]*AZResourceUsageReport {
+	result := make(map[AvailabilityZone]*AZResourceUsageReport, len(allAZs)+1)
+	for _, az := range allAZs {
+		var empty AZResourceUsageReport
+		result[az] = &empty
+	}
+	if r.Usage > 0 {
+		result[AvailabilityZoneUnknown] = &r
+	}
+	return result
+}
+
+// AddLocalizedUsage subtracts the given `usage from AvailabilityZoneUnknown (if any) and adds it to the given AZ instead.
+//
+// This is used when breaking down a usage total reported by a non-AZ-aware API by iterating over AZ-localized objects.
+// The hope is that the sum of usage of the AZ-localized objects matches the reported usage total.
+// If this is the case, the entry for AvailabilityZoneUnknown will be removed entirely once it reaches zero usage.
+func (r *ResourceUsageReport) AddLocalizedUsage(az AvailabilityZone, usage uint64) {
+	if u := r.PerAZ[AvailabilityZoneUnknown]; u == nil || u.Usage <= usage {
+		delete(r.PerAZ, AvailabilityZoneUnknown)
+	} else {
+		r.PerAZ[AvailabilityZoneUnknown].Usage -= usage
+	}
+
+	if _, exists := r.PerAZ[az]; exists {
+		r.PerAZ[az].Usage += usage
+	} else {
+		r.PerAZ[az] = &AZResourceUsageReport{Usage: usage}
+	}
+}

--- a/liquid/subdivisions.go
+++ b/liquid/subdivisions.go
@@ -1,0 +1,125 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package liquid
+
+import "encoding/json"
+
+// Subcapacity describes a distinct chunk of capacity for a resource within an AZ.
+// It appears in type AZResourceCapacityReport.
+//
+// A service will only report subcapacities for such resources where there is a useful substructure to report.
+// For example:
+//   - Nova can report its hypervisors as subcapacities of the "cores" and "ram" resources.
+//   - Cinder can report its storage pools as subcapacities of the "capacity" resource.
+//
+// The required fields are "Capacity" and at least one of "ID" or "Name".
+//
+// There is no guarantee that the Capacity values of all subcapacities sum up to the total capacity of the resource.
+// For example, some subcapacities may be excluded from new provisioning.
+// The capacity calculation could then take this into account and exclude unused capacity from the total.
+type Subcapacity struct {
+	// A machine-readable unique identifier for this subcapacity, if there is one.
+	ID string `json:"id,omitempty"`
+
+	// A human-readable unique identifier for this subcapacity, if there is one.
+	Name string `json:"name,omitempty"`
+
+	// The amount of capacity in this subcapacity.
+	Capacity uint64 `json:"capacity"`
+
+	// How much of the Capacity is used, or null if no usage data is available.
+	Usage *uint64 `json:"usage,omitempty"`
+
+	// Additional resource-specific attributes.
+	// This must be shaped like a map[string]any, but is typed as a raw JSON message.
+	// Limes does not touch these attributes and will just pass them on into its users without deserializing it at all.
+	Attributes json.RawMessage `json:"attributes,omitempty"`
+}
+
+// SubcapacityBuilder is a helper type for building Subcapacity values.
+// If the Attributes in a subcapacity are collected over time, it might be more convenient to have them accessible as a structured type.
+// Once assembly is complete, the provided methods can be used to obtain the final Subcapacity value.
+type SubcapacityBuilder[A any] struct {
+	ID         string
+	Name       string
+	Capacity   uint64
+	Usage      *uint64
+	Attributes A
+}
+
+// Finalize converts this SubcapacityBuilder into a Subcapacity by serializing the Attributes field to JSON.
+// If an error is returned, it is from the json.Marshal() step.
+func (b SubcapacityBuilder[A]) Finalize() (Subcapacity, error) {
+	buf, err := json.Marshal(b.Attributes)
+	return Subcapacity{
+		ID:         b.ID,
+		Name:       b.Name,
+		Capacity:   b.Capacity,
+		Usage:      b.Usage,
+		Attributes: json.RawMessage(buf),
+	}, err
+}
+
+// Subresource describes a distinct chunk of usage for a resource within a project and AZ.
+// It appears in type AZResourceUsageReport.
+//
+// A service will only report subresources for such resources where there is a useful substructure to report.
+// For example, in the Nova resource "instances", each instance is a subresource.
+//
+// The required fields are "Size" (only for measured resources) and at least one of "ID" or "Name".
+type Subresource struct {
+	// A machine-readable unique identifier for this subresource, if there is one.
+	ID string `json:"id,omitempty"`
+
+	// A human-readable identifier for this subresource, if there is one.
+	// Must be unique at least within its project.
+	Name string `json:"name,omitempty"`
+
+	// Must be null for counted resources (for which each subresource must be one of the things that is counted).
+	// Must be non-null for measured resources, and contain the subresource's size in terms of the resource's unit.
+	Usage *uint64 `json:"usage,omitempty"`
+
+	// Additional resource-specific attributes.
+	// This must be shaped like a map[string]any, but is typed as a raw JSON message.
+	// Limes does not touch these attributes and will just pass them on into its users without deserializing it at all.
+	Attributes json.RawMessage `json:"attributes,omitempty"`
+}
+
+// SubresourceBuilder is a helper type for building Subresource values.
+// If the Attributes in a subresource are collected over time, it might be more convenient to have them accessible as a structured type.
+// Once assembly is complete, the provided methods can be used to obtain the final Subresource value.
+type SubresourceBuilder[A any] struct {
+	ID         string
+	Name       string
+	Usage      *uint64
+	Attributes A
+}
+
+// Finalize converts this SubresourceBuilder into a Subresource by serializing the Attributes field to JSON.
+// If an error is returned, it is from the json.Marshal() step.
+func (b SubresourceBuilder[A]) Finalize() (Subresource, error) {
+	buf, err := json.Marshal(b.Attributes)
+	return Subresource{
+		ID:         b.ID,
+		Name:       b.Name,
+		Usage:      b.Usage,
+		Attributes: json.RawMessage(buf),
+	}, err
+}

--- a/liquid/unit.go
+++ b/liquid/unit.go
@@ -1,0 +1,119 @@
+/*******************************************************************************
+*
+* Copyright 2017-2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package liquid
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Unit enumerates allowed values for the unit a resource's quota/usage is
+// measured in.
+type Unit string
+
+const (
+	// UnitNone is used for countable (rather than measurable) resources.
+	UnitNone Unit = ""
+	// UnitBytes is exactly that.
+	UnitBytes Unit = "B"
+	// UnitKibibytes is exactly that.
+	UnitKibibytes Unit = "KiB"
+	// UnitMebibytes is exactly that.
+	UnitMebibytes Unit = "MiB"
+	// UnitGibibytes is exactly that.
+	UnitGibibytes Unit = "GiB"
+	// UnitTebibytes is exactly that.
+	UnitTebibytes Unit = "TiB"
+	// UnitPebibytes is exactly that.
+	UnitPebibytes Unit = "PiB"
+	// UnitExbibytes is exactly that.
+	UnitExbibytes Unit = "EiB"
+	// UnitUnspecified is used as a placeholder when the unit is not known.
+	UnitUnspecified Unit = "UNSPECIFIED"
+)
+
+var allValidUnits = []Unit{
+	UnitNone,
+	UnitBytes,
+	UnitKibibytes,
+	UnitMebibytes,
+	UnitGibibytes,
+	UnitTebibytes,
+	UnitPebibytes,
+	UnitExbibytes,
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+// This method validates that the named unit actually exists.
+//
+// Deprecated: This provides backwards-compatibility with existing YAML-based config file formats in Limes which will be replaced by JSON eventually.
+func (u *Unit) UnmarshalYAML(unmarshal func(any) error) error {
+	var s string
+	err := unmarshal(&s)
+	if err != nil {
+		return err
+	}
+	for _, unit := range allValidUnits {
+		if string(unit) == s {
+			*u = unit
+			return nil
+		}
+	}
+	return fmt.Errorf("unknown unit: %q", s)
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+// This method validates that the named unit actually exists.
+func (u *Unit) UnmarshalJSON(buf []byte) error {
+	var s string
+	err := json.Unmarshal(buf, &s)
+	if err != nil {
+		return err
+	}
+	for _, unit := range allValidUnits {
+		if string(unit) == s {
+			*u = unit
+			return nil
+		}
+	}
+	return fmt.Errorf("unknown unit: %q", s)
+}
+
+// Base returns the base unit of this unit. For units defined as a multiple of
+// another unit, that unit is the base unit. Otherwise, the same unit and a
+// multiple of 1 is returned.
+func (u Unit) Base() (Unit, uint64) { //nolint:gocritic // not necessary to name the results
+	switch u {
+	case UnitKibibytes:
+		return UnitBytes, 1 << 10
+	case UnitMebibytes:
+		return UnitBytes, 1 << 20
+	case UnitGibibytes:
+		return UnitBytes, 1 << 30
+	case UnitTebibytes:
+		return UnitBytes, 1 << 40
+	case UnitPebibytes:
+		return UnitBytes, 1 << 50
+	case UnitExbibytes:
+		return UnitBytes, 1 << 60
+	default:
+		return u, 1
+	}
+}


### PR DESCRIPTION
LIQUID is the protocol spec for a decoupling effort in which I want to isolate the service-specific quota/usage/capacity scraping and quota setting logic within Limes and make those more pluggable, and also make some improvements to the internal architecture of Limes along the way.

LIQUID is derived from the existing [internal `QuotaPlugin` and `CapacityPlugin` interfaces in Limes](https://github.com/sapcc/limes/blob/master/internal/core/plugin.go), but turned from an internal Go interface to an OpenStack-like REST API. Some more notes on specific parts of the design:

* Before writing the spec like this, I did a trial run with OpenAPI (aka Swagger) and found OpenAPI type definitions significantly more tedious to write than straight-up Go types, with not a lot of gain from all that complication. (In fact, the autogenerated types were much more ugly than what I hand-rolled here.) If this is merged, I intend for the "canonical URL" of the spec to be pkg.go.dev of `package liquid`.
* Several basic types that currently exist in `limes/` and `limes/resources/` (AvailabilityZone, ResourceName, Unit) are moved into `liquid/` and aliased back into their original locations for source compatibility. I'm doing it this way instead of the other way around because the `limes/` stuff is the Limes v1 API that I want to get rid of soonish, whereas LIQUID is explicitly designed to stay for a long time.
* For `Unit` specifically, `Unit.Parse()` is out of scope of what LIQUID covers, so I convered it into a freestanding function. This is technically a break of backwards-compatbility, but the only current user of this method is right in this repo, so I adjusted the callsite as part of this PR.
* Several convenience methods (`InAnyAZ`, `PrepareForBreakdownInto` and `AddLocalizedUsage`, and all methods on `type OvercommitFactor`) come from Limes core and are brought in here because I know from experience with the existing QuotaPlugin/CapacityPlugin implementations that liquids will want to use these functions.
* The `ServiceInfo.Version` mechanism is currently without precedent in Limes, but something I have been wanting for a long time. Currently, whenever resource definitions change (e.g. because the baremetal team adds or deletes flavors), all Limes components need to be restarted manually, which is stupid. The versioning mechanism is designed to let Limes react to such changes automatically (assuming that the liquid has polling logic to discover the respective changes). Initially, I plan on having a `ServiceInfo.Version` mismatch be a fatal error inside Limes, so that the restart after crash will serve as a reload. Eventually, Limes should get smarter about this though.