### PR TITLE
Add conversion API type

### DIFF
--- a/limes/resources/commitment.go
+++ b/limes/resources/commitment.go
@@ -71,9 +71,9 @@ type CommitmentRequest struct {
 // CommitmentConversion is the API representation of a commitment that can be converted to another resource type.
 // From and To are used to represent the fracture of Up and Down conversions.
 type CommitmentConversion struct {
-	From        uint64 `json:"from"`
-	To          uint64 `json:"to"`
-	Convertible string `json:"convertible"`
+	From           uint64 `json:"from"`
+	To             uint64 `json:"to"`
+	TargetResource string `json:"target_resource"`
 }
 
 // CommitmentTransferStatus is an enum.

--- a/limes/resources/commitment.go
+++ b/limes/resources/commitment.go
@@ -68,6 +68,12 @@ type CommitmentRequest struct {
 	ConfirmBy        *limes.UnixEncodedTime `json:"confirm_by,omitempty"`
 }
 
+// CommitmentConversion is the API representation of a commitment that can be converted to another resource type.
+type CommitmentConversion struct {
+	Amount      uint64 `json:"amount"`
+	Convertible string `json:"convertible"`
+}
+
 // CommitmentTransferStatus is an enum.
 type CommitmentTransferStatus string
 

--- a/limes/resources/commitment.go
+++ b/limes/resources/commitment.go
@@ -69,8 +69,10 @@ type CommitmentRequest struct {
 }
 
 // CommitmentConversion is the API representation of a commitment that can be converted to another resource type.
+// From and To are used to represent the fracture of Up and Down conversions.
 type CommitmentConversion struct {
-	Amount      uint64 `json:"amount"`
+	From        uint64 `json:"from"`
+	To          uint64 `json:"to"`
 	Convertible string `json:"convertible"`
 }
 

--- a/limes/resources/commitment.go
+++ b/limes/resources/commitment.go
@@ -73,7 +73,7 @@ type CommitmentRequest struct {
 type CommitmentConversion struct {
 	From           uint64 `json:"from"`
 	To             uint64 `json:"to"`
-	TargetResource string `json:"target_resource"`
+	TargetResource ResourceName `json:"target_resource"`
 }
 
 // CommitmentTransferStatus is an enum.


### PR DESCRIPTION
To convert a commitment to another resource type I plan to introduce two API endpoints.

The first one is a GET `/v1/commitments/{service_type}/{resource_name}` endpoint. It reads the configuration data of a resource type and decides if a commitment can be converted to a target resource. For this I would like to include the API type from this PR wich includes the amount and the resource type a commitment might be converted to.
(We could also include this information to the GET commitments endpoint, but I would rather not include this information to every single commitment. Because:
a: We would lose the conversion information if we have no matching commitment
b: We add a load of duplicate data to the commitments and the response JSON.)

The second one will be a POST endpoint that receives the commitment to transfer and the convertible which then tries to convert that commitment to its target.