### PR TITLE
liquid: add ProjectMetadata signaling mechanism

### DIFF
--- a/liquid/info.go
+++ b/liquid/info.go
@@ -42,6 +42,12 @@ type ServiceInfo struct {
 
 	// Info for each metric family that is included in a response to a query for project quota and usage.
 	UsageMetricFamilies map[MetricName]MetricFamilyInfo `json:"usageMetricFamilies"`
+
+	// Whether Limes needs to include the ProjectMetadata field in its requests for usage reports.
+	UsageReportNeedsProjectMetadata bool `json:"usageReportNeedsProjectMetadata,omitempty"`
+
+	// Whether Limes needs to include the ProjectMetadata field in its quota update requests.
+	QuotaUpdateNeedsProjectMetadata bool `json:"quotaUpdateNeedsProjectMetadata,omitempty"`
 }
 
 // ResourceInfo describes a resource that a liquid's service provides.
@@ -62,4 +68,21 @@ type ResourceInfo struct {
 	// If false, only usage is reported on the project level.
 	// Limes will abstain from maintaining quota on such resources.
 	HasQuota bool `json:"hasQuota"`
+}
+
+// ProjectMetadata includes metadata about a project from Keystone.
+//
+// It appears in types ServiceUsageRequest and ServiceQuotaRequest if requested by the ServiceInfo.
+type ProjectMetadata struct {
+	UUID   string         `json:"uuid"`
+	Name   string         `json:"name"`
+	Domain DomainMetadata `json:"domain"`
+}
+
+// DomainMetadata includes metadata about a domain from Keystone.
+//
+// It appears in type ProjectMetadata.
+type DomainMetadata struct {
+	UUID string `json:"uuid"`
+	Name string `json:"name"`
 }

--- a/liquid/quota.go
+++ b/liquid/quota.go
@@ -22,6 +22,10 @@ package liquid
 // ServiceQuotaRequest is the request payload format for PUT /v1/projects/:uuid/quota.
 type ServiceQuotaRequest struct {
 	Resources map[ResourceName]ResourceQuotaRequest `json:"resources"`
+
+	// Metadata about the project from Keystone.
+	// Only included if the ServiceInfo declared a need for it.
+	ProjectMetadata *ProjectMetadata `json:"projectMetadata,omitempty"`
 }
 
 // ResourceQuotaRequest contains the new quota value for a single resource.

--- a/liquid/report_usage.go
+++ b/liquid/report_usage.go
@@ -27,6 +27,10 @@ type ServiceUsageRequest struct {
 	//   - usage belonging to an invalid AZ is grouped into AvailabilityZoneUnknown.
 	// Limes provides this list here to reduce the number of places where this information needs to be maintained manually.
 	AllAZs []AvailabilityZone `json:"allAZs"`
+
+	// Metadata about the project from Keystone.
+	// Only included if the ServiceInfo declared a need for it.
+	ProjectMetadata *ProjectMetadata `json:"projectMetadata,omitempty"`
 }
 
 // ServiceUsageReport is the response payload format for POST /v1/projects/:uuid/report-usage.


### PR DESCRIPTION
While trying to convert the QuotaPlugin for Manila into a liquid, I noticed that its share type configuration matches projects and domains by name. So as a liquid, given only the project ID, it would have to query Keystone for name and domain association on every single usage report. I find that excessive, esp. considering that Limes already has this information available.

This change also adds the same signaling to ServiceQuotaRequest. This will be useful for liquid-swift: It needs the domain ID when setting quota. Since SetQuota is rarer than ReportUsage, I considered it fine there to just query Keystone directly, but if we're changing this anyway, we're making the full change.

Zooming out into the big picture, this PR demonstrates how I intend to evolve the LIQUID spec in a backwards-compatible way (from the perspective of the liquid implementations). When a protocol extension is added, liquids need to signal their willingness to use it through the ServiceInfo, and only then will Limes include the respective data in requests (or consume the respective data in responses).