### PR TITLE
cadf resource id omit empty

### DIFF
--- a/cadf/event.go
+++ b/cadf/event.go
@@ -78,7 +78,7 @@ type Resource struct {
 	TypeURI   string `json:"typeURI"`
 	Name      string `json:"name,omitempty"`
 	Domain    string `json:"domain,omitempty"`
-	ID        string `json:"id"`
+	ID        string `json:"id,omitempty"`
 	Addresses []struct {
 		URL  string `json:"url"`
 		Name string `json:"name,omitempty"`

--- a/limes/unit_test.go
+++ b/limes/unit_test.go
@@ -38,8 +38,8 @@ func assertConvertError(t *testing.T, from ValueWithUnit, to Unit, expectedError
 		t.Errorf("expected error when converting %s to %s, but found err == nil", from.String(), string(to))
 	case err.Error() != expectedError:
 		t.Errorf("unexpected error when converting %s to %s", from.String(), string(to))
-		t.Logf("  expected: " + expectedError)
-		t.Logf("    actual: " + err.Error())
+		t.Logf("  expected: %s", expectedError)
+		t.Logf("    actual: %s", err.Error())
 	}
 }
 


### PR DESCRIPTION
In a specific case, we are renaming the id to be project_id now for multiple reasons.

if [target][id] and [target][typeURI] == "data/security/project" {
    mutate {
      id => "f06c_move_target_id_to_project_id"
      add_field => { "[target][project_id]" => "%{[target][id]}" }
      remove_field => [ "[target][id]" ]
    }
  }

This means that we need to make ID omitempty as we remove id when it moves to project_id in cases this occurs. 

I can't think of any issues with doing this. If it doesn't exist, it shouldn't be returned. 