### PR TITLE
liquid: add support for rates

### DIFF
--- a/liquid/doc.go
+++ b/liquid/doc.go
@@ -30,14 +30,20 @@
 //   - "A liquid" (lower case) refers to a server implementing LIQUID.
 //   - "The liquid's service" refers to the OpenStack service that the liquid is a part of or connected to.
 //
-// Each liquid provides access to one or more resources.
-// A resource is any countable or measurable kind of entity managed by the liquid's service.
+// Each liquid provides access to zero or more resources and zero or more rates:
+//   - A resource is any countable or measurable kind of entity managed by the liquid's service.
+//   - A rate is any countable or measurable series of events or transfers managed by the liquid's service.
 //
 // Limes discovers liquids through the Keystone service catalog.
 // Each liquid should be registered there with a service type that has the prefix "liquid-".
 // If a liquid uses vendor-specific APIs to interact with its service, its service type should include the vendor name.
 //
 // # Inside a resource: Usage, quota, capacity, overcommit
+//
+// Resources describe objects that are provisioned at some point and then kept around until they are later deleted.
+// Examples of resources include VMs in a compute service, volumes in a storage service, or floating IPs in a network service.
+// (This does not mean that each individual floating IP is a resource. The entire concept of "floating IPs" is the resource.)
+// Resource usage and capacity is always measured at a specific point in time, like for the Prometheus metric type "gauge".
 //
 // All resources report a usage value for each Keystone project.
 // This describes how much of the resource is used by objects created within the project.
@@ -58,7 +64,17 @@
 // Capacity and usage may be AZ-aware, in which case one value will be reported per availability zone (AZ).
 // Quota is not modelled as AZ-aware since there are no OpenStack services that support AZ-aware quota at this time.
 //
-// # Structure
+// # Inside a rate: Usage
+//
+// Rates are measurements that only ever increase over time, similar to the Prometheus metric type "counter".
+// For example, if a compute service has the resource "VMs", it might have rates like "VM creations" or "VM deletions".
+// Rates describe countable events like in this example, or measurable transfers like "bytes transferred" on network links.
+//
+// All rates report a usage value for each Keystone project.
+// Usage for each project must increase monotonically over time.
+// Usage may be AZ-aware, in which case one value will be reported per availability zone (AZ).
+//
+// # API structure
 //
 // LIQUID is structured as a REST-like HTTP API akin to those of the various OpenStack services.
 // Like with any other OpenStack API, the client (i.e. Limes) authenticates to the liquid by providing its Keystone token in the HTTP header "X-Auth-Token".
@@ -115,6 +131,10 @@
 // [Prometheus]: https://prometheus.io/
 package liquid
 
-// ResourceName identifies a resource within a service. This type is used to distinguish
-// resource names from other types of string values in function signatures.
+// ResourceName identifies a resource within a service.
+// This type is used to distinguish resource names from other types of string values in function signatures.
 type ResourceName string
+
+// RateName identifies a rate within a service.
+// This type is used to distinguish rate names from other types of string values in function signatures.
+type RateName string

--- a/liquid/info.go
+++ b/liquid/info.go
@@ -37,6 +37,9 @@ type ServiceInfo struct {
 	// Info for each resource that this service provides.
 	Resources map[ResourceName]ResourceInfo `json:"resources"`
 
+	// Info for each rate that this service provides.
+	Rates map[RateName]RateInfo `json:"rates"`
+
 	// Info for each metric family that is included in a response to a query for cluster capacity.
 	CapacityMetricFamilies map[MetricName]MetricFamilyInfo `json:"capacityMetricFamilies"`
 
@@ -54,7 +57,7 @@ type ServiceInfo struct {
 // This type appears in type ServiceInfo.
 type ResourceInfo struct {
 	// If omitted or empty, the resource is "countable" and any quota or usage values describe a number of objects.
-	// If non-empty, the resource is "measured" and quota or usage values are measured in the given unit.
+	// If non-empty, the resource is "measured" and quota or usage values are in multiples of the given unit.
 	// For example, the compute resource "cores" is countable, but the compute resource "ram" is measured, usually in MiB.
 	Unit Unit `json:"unit,omitempty"`
 
@@ -68,6 +71,20 @@ type ResourceInfo struct {
 	// If false, only usage is reported on the project level.
 	// Limes will abstain from maintaining quota on such resources.
 	HasQuota bool `json:"hasQuota"`
+}
+
+// RateInfo describes a rate that a liquid's service provides.
+// This type appears in type ServiceInfo.
+type RateInfo struct {
+	// If omitted or empty, the rate is "countable" and usage values describe a number of events.
+	// If non-empty, the rate is "measured" and usage values are in multiples of the given unit.
+	// For example, the storage rate "volume_creations" is countable, but the network rate "outbound_transfer" is measured, e.g. in bytes.
+	Unit Unit `json:"unit,omitempty"`
+
+	// Whether the liquid reports usage for this rate on the project level.
+	// This must currently be true because there is no other reason for a rate to exist.
+	// This requirement may be relaxed in the future, if LIQUID starts modelling rate limits and there are rates that have limits, but no usage tracking.
+	HasUsage bool `json:"hasUsage"`
 }
 
 // ProjectMetadata includes metadata about a project from Keystone.

--- a/liquid/report_capacity.go
+++ b/liquid/report_capacity.go
@@ -68,10 +68,10 @@ type ServiceCapacityReport struct {
 	InfoVersion int64 `json:"infoVersion"`
 
 	// Must contain an entry for each resource that was declared in type ServiceInfo with "HasCapacity = true".
-	Resources map[ResourceName]*ResourceCapacityReport `json:"resources"`
+	Resources map[ResourceName]*ResourceCapacityReport `json:"resources,omitempty"`
 
 	// Must contain an entry for each metric family that was declared for capacity metrics in type ServiceInfo.
-	Metrics map[MetricName][]Metric `json:"metrics"`
+	Metrics map[MetricName][]Metric `json:"metrics,omitempty"`
 }
 
 // ResourceCapacityReport contains capacity data for a resource.


### PR DESCRIPTION
This is modeled on the existing `QuotaPlugin.ScrapeRates` facility in Limes. The rate scraping and resource scraping are currently split in Limes, but I intend to merge them into one loop since there never was any benefit from keeping them separate (and it just creates a bunch of useless parallel structures).

The remark about SerializedState not working for liquids that have resources is because, in Limes, `serializedState` is only carried through `ScrapeRates` and not through `Scrape` (the latter of which handles resources).

I also used the opportunity to add some more `omitempty` in usage reports where they make sense. This is a backwards-compatible change because Limes does not care either way about map fields being omitted or `null`.