### PR TITLE
liquid: add support for AZ-aware quotas

### DIFF
--- a/liquid/doc.go
+++ b/liquid/doc.go
@@ -62,7 +62,7 @@
 // In this case, quota and usage values are in terms of effective capacity, even though the capacity value is in terms of raw capacity.
 //
 // Capacity and usage may be AZ-aware, in which case one value will be reported per availability zone (AZ).
-// Quota is not modelled as AZ-aware since there are no OpenStack services that support AZ-aware quota at this time.
+// Quota is only optionally modelled as AZ-aware since there are no OpenStack services that support AZ-aware quota at this time.
 //
 // # Inside a rate: Usage
 //

--- a/liquid/info.go
+++ b/liquid/info.go
@@ -97,20 +97,32 @@ const (
 	// FlatResourceTopology is a topology for resources that are not AZ-aware at all.
 	// In reports for this resource, PerAZ must contain exactly one key: AvailabilityZoneAny.
 	// Any other entry, as well as the absence of AvailabilityZoneAny, will be considered an error by Limes.
+	//
+	// If the resource sets HasQuota = true, only a flat number will be given, and PerAZ will be null.
 	FlatResourceTopology ResourceTopology = "flat"
 
-	// AZAwareResourceTopology is a topology for resources that are AZ-aware.
+	// AZAwareResourceTopology is a topology for resources that can measure capacity and usage by AZ.
 	// In reports for this resource, PerAZ shall contain an entry for each AZ mentioned in the AllAZs key of the request.
 	// PerAZ may also include an entry for AvailabilityZoneUnknown as needed.
 	// Any other entry (including AvailabilityZoneAny) will be considered an error by Limes.
+	//
+	// If the resource sets "HasQuota = true", only a flat number will be given, and PerAZ will be null.
+	// This behavior matches the AZ-unawareness of quota in most OpenStack services.
 	AZAwareResourceTopology ResourceTopology = "az-aware"
+
+	// AZSeparatedResourceTopology is like AZAwareResourceTopology, but quota is also AZ-aware.
+	// For resources with HasQuota = false, this behaves the same as AZAwareResourceTopology.
+	//
+	// If the resource sets "HasQuota = true", quota requests will include the PerAZ breakdown.
+	// PerAZ will only contain quotas for actual AZs, not for AvailabilityZoneAny or AvailabilityZoneUnknown.
+	AZSeparatedResourceTopology ResourceTopology = "az-separated"
 )
 
 // IsValid returns whether the given value is a part of the enum.
 // This can be used to check unmarshalled values.
 func (t ResourceTopology) IsValid() bool {
 	switch t {
-	case FlatResourceTopology, AZAwareResourceTopology:
+	case FlatResourceTopology, AZAwareResourceTopology, AZSeparatedResourceTopology:
 		return true
 	default:
 		return false

--- a/liquid/quota.go
+++ b/liquid/quota.go
@@ -28,12 +28,23 @@ type ServiceQuotaRequest struct {
 	ProjectMetadata *ProjectMetadata `json:"projectMetadata,omitempty"`
 }
 
-// ResourceQuotaRequest contains the new quota value for a single resource.
+// ResourceQuotaRequest contains new quotas for a single resource.
 // It appears in type ServiceQuotaRequest.
 type ResourceQuotaRequest struct {
+	// For FlatResourceTopology and AZAwareResourceTopology, this is the only field that is filled, and PerAZ will be nil.
+	// For AZSeparatedResourceTopology, this contains the sum of the quotas across all AZs (for compatibility purposes).
+	Quota uint64 `json:"quota"`
+
+	// PerAZ will only be filled for AZSeparatedResourceTopology.
+	PerAZ map[AvailabilityZone]AZResourceQuotaRequest `json:"perAZ,omitempty"`
+}
+
+// AZResourceQuotaRequest contains the new quota value for a single resource and AZ.
+// It appears in type ResourceQuotaRequest.
+type AZResourceQuotaRequest struct {
 	Quota uint64 `json:"quota"`
 
 	// This struct looks superfluous (why not just have a bare uint64?), but in
-	// the unlikely event that AZ-aware quota may be added in the future, having
-	// this struct allows for that to be a backwards-compatible change.
+	// the event that more data needs to be added in the future, having this
+	// struct allows for that to be a backwards-compatible change.
 }

--- a/liquid/report_capacity.go
+++ b/liquid/report_capacity.go
@@ -88,6 +88,20 @@ type ResourceCapacityReport struct {
 // AZResourceCapacityReport contains capacity data for a resource in a single AZ.
 // It appears in type ResourceCapacityReport.
 type AZResourceCapacityReport struct {
+	// How much capacity is available to Limes in this resource and AZ.
+	//
+	// Caution: In some cases, underlying capacity can be used by multiple
+	// resources. For example, the storage capacity in Manila pools can be used
+	// by both the `share_capacity` and `snapshot_capacity` resources. In this case,
+	// it is *incorrect* to just report the entire storage capacity in both resources.
+	// Limes assumes that whatever number you provide here is free to be
+	// allocated exclusively for the respective resource. If physical capacity
+	// can be used by multiple resources, you need to split the capacity and
+	// report only a chunk of the real capacity in each resource.
+	//
+	// If you need to split physical capacity between multiple resources like
+	// this, the recommended way is to set "NeedsResourceDemand = true" and
+	// then split capacity based on the demand reported by Limes.
 	Capacity uint64 `json:"capacity"`
 
 	// How much of the Capacity is used, or null if no usage data is available.

--- a/liquid/report_capacity.go
+++ b/liquid/report_capacity.go
@@ -41,7 +41,7 @@ type ResourceDemand struct {
 	OvercommitFactor OvercommitFactor `json:"overcommitFactor,omitempty"`
 
 	// The actual demand values are AZ-aware.
-	// For non-AZ-aware resources, the only entry will be for AvailabilityZoneAny.
+	// The keys that can be expected in this map depend on the chosen ResourceTopology.
 	PerAZ map[AvailabilityZone]ResourceDemandInAZ `json:"perAZ"`
 }
 
@@ -77,11 +77,8 @@ type ServiceCapacityReport struct {
 // ResourceCapacityReport contains capacity data for a resource.
 // It appears in type ServiceCapacityReport.
 type ResourceCapacityReport struct {
-	// For non-AZ-aware resources, the only entry shall be for AvailabilityZoneAny.
-	// Use func InAnyAZ to quickly construct a suitable structure.
-	//
-	// For AZ-aware resources, there shall be an entry for each AZ mentioned in ServiceCapacityRequest.AllAZs.
-	// Reports for AZ-aware resources may also include an entry for AvailabilityZoneUnknown as needed.
+	// The keys that are allowed in this map depend on the chosen ResourceTopology.
+	// See documentation on ResourceTopology enum variants for details.
 	PerAZ map[AvailabilityZone]*AZResourceCapacityReport `json:"perAZ"`
 }
 

--- a/liquid/report_usage.go
+++ b/liquid/report_usage.go
@@ -81,12 +81,10 @@ type ResourceUsageReport struct {
 	// A negative value, usually -1, indicates "infinite quota" (i.e., the absence of a quota).
 	Quota *int64 `json:"quota,omitempty"`
 
-	// For non-AZ-aware resources, the only entry shall be for AvailabilityZoneAny.
-	// Use func InAnyAZ to quickly construct a suitable structure.
+	// The keys that are allowed in this map depend on the chosen ResourceTopology.
+	// See documentation on ResourceTopology enum variants for details.
 	//
-	// For AZ-aware resources, there shall be an entry for each AZ mentioned in ServiceUsageRequest.AllAZs.
-	// Reports for AZ-aware resources may also include an entry for AvailabilityZoneUnknown as needed.
-	// When starting from a non-AZ-aware usage number that is later broken down with AZ-aware data, use func PrepareForBreakdownInto.
+	// Tip: When filling this by starting from a non-AZ-aware usage number that is later broken down with AZ-aware data, use func PrepareForBreakdownInto.
 	PerAZ map[AvailabilityZone]*AZResourceUsageReport `json:"perAZ"`
 }
 
@@ -148,11 +146,8 @@ func (r *ResourceUsageReport) AddLocalizedUsage(az AvailabilityZone, usage uint6
 // RateUsageReport contains usage data for a rate in a single project.
 // It appears in type ServiceUsageReport.
 type RateUsageReport struct {
-	// For non-AZ-aware rates, the only entry shall be for AvailabilityZoneAny.
-	// Use func InAnyAZ to quickly construct a suitable structure.
-	//
-	// For AZ-aware rates, there shall be an entry for each AZ mentioned in ServiceUsageRequest.AllAZs.
-	// Reports for AZ-aware rates may also include an entry for AvailabilityZoneUnknown as needed.
+	// The keys that are allowed in this map depend on the chosen ResourceTopology.
+	// See documentation on ResourceTopology enum variants for details.
 	PerAZ map[AvailabilityZone]*AZRateUsageReport `json:"perAZ"`
 }
 

--- a/liquid/report_usage.go
+++ b/liquid/report_usage.go
@@ -77,7 +77,7 @@ type ResourceUsageReport struct {
 	//   - If the project has no usage in this resource, Limes will hide this resource from project reports.
 	Forbidden bool `json:"forbidden"`
 
-	// This shall be null if and only if the resource is declared with "HasQuota = false".
+	// This shall be null if and only if the resource is declared with "HasQuota = false" or with AZSeparatedResourceTopology.
 	// A negative value, usually -1, indicates "infinite quota" (i.e., the absence of a quota).
 	Quota *int64 `json:"quota,omitempty"`
 
@@ -101,6 +101,10 @@ type AZResourceUsageReport struct {
 	// If a project has 5 shares, each with 10 GiB size and each containing 1 GiB data, then Usage = 50 GiB and PhysicalUsage = 5 GiB.
 	// It is not allowed to report 5 GiB as Usage in this situation, since the 50 GiB value is used when judging whether the Quota fits.
 	PhysicalUsage *uint64 `json:"physicalUsage,omitempty"`
+
+	// This shall be non-null if and only if the resource is declared with AZSeparatedResourceTopology.
+	// A negative value, usually -1, indicates "infinite quota" (i.e., the absence of a quota).
+	Quota *int64 `json:"quota,omitempty"`
 
 	// Only filled if the resource is able to report subresources for this usage in a useful way.
 	Subresources []Subresource `json:"subresources,omitempty"`

--- a/liquid/report_usage.go
+++ b/liquid/report_usage.go
@@ -73,7 +73,7 @@ type ServiceUsageReport struct {
 type ResourceUsageReport struct {
 	// If true, this project is forbidden from accessing this resource.
 	// This has two consequences:
-	//   - If the resource has quota, Limes will never try to assign quota for this resource to this project.
+	//   - If the resource has quota, Limes will never try to assign quota for this resource to this project except to cover existing usage.
 	//   - If the project has no usage in this resource, Limes will hide this resource from project reports.
 	Forbidden bool `json:"forbidden"`
 


### PR DESCRIPTION
This is becoming a requirement for liquid-ceph: We will have several storage classes grouped into a single resource as the resource's AZ slots. Using placeholder names for illustrative purposes, there might be several storage classes like:

- "3 replicas in AZ a"
- "3 replicas in AZ b"
- and so on

I recommended against modelling those as separate AZ-unaware resources, so these will be grouped into a single resource "3 replicas in the same AZ". The main consequence from this is that LIQUID needs to add support for AZ-aware quotas (instead of just AZ-aware capacity and usage).

So an additional configuration is needed in `type ResourceInfo`. To avoid turning ResourceInfo into a sea of interconnected booleans, I'm introducing a new enum `type ResourceTopology`. The existing two behaviors are described by `FlatResourceTopology` (no AZ-awareness, everything is in AZ `any`) and `AZAwareResourceTopology` (AZ-awareness for usage and capacity, but not quota), and the new behavior is `AZSeparatedResourceTopology` (AZ-awareness for usage and capacity and also quota). As part of this, the previously implicit differentiation between flat and AZ-aware topology becomes explicit now, in order for Limes to become able to act as a kind of linter for liquid behavior.

To give a preview of the implementation scope for Limes, this means that:

1. When reading any response from a liquid, we need to validate the PerAZ fields against the declared topology. For example, if a resource is declared with `AZAwareResourceTopology`, a capacity report for AZ `any` shall be rejected because only known AZs and `unknown` are allowed for this topology. This is an easy change that is localized to the LIQUID plugin bridge. (In the future, we can think about using the topology to optimize algorithms inside Limes, but that probably won't be in scope for the initial work package. For example, the `commitment_is_az_aware` config flag can be replaced by a check for the selected topology.)
2. When writing quota, we need to break down quota values by AZ for resources with `AZSeparatedResourceTopology`. This is another easy change: We already have the AZ quotas in our DB, we just need to put them in the request.
3. When collecting usage data, we need to read quota values broken down by AZ for `AZSeparatedResourceTopology`. This is a slightly larger change that involves adding `project_az_resources.backend_quota` to the DB schema, but not too bad, either.
4. The trouble happens when calculating AZ quotas. When applying a base quota, we currently put it in AZ `any`. But this does not make sense for the storage class scenario described above: Which distinct storage class would you give the quota for storage class `any`? We cannot divide it between storage classes because `SetQuota` only sees the numbers for one specific project and does not have any information about capacity distribution. My best idea right now is to treat the configured base quota as applying for each AZ separately for `AZSeparatedResourceTopology`, but I'll let this problem simmer in my head a bit longer before deciding on a solution. What's clear is that we need some solution because base quota is going to be desirable for Ceph resources eventually.