### PR TITLE
liquid: add func NormalizeAZ()

### DIFF
--- a/liquid/availability_zone.go
+++ b/liquid/availability_zone.go
@@ -19,6 +19,8 @@
 
 package liquid
 
+import "slices"
+
 // AvailabilityZone is the name of an availability zone.
 // Some special values are enumerated below.
 type AvailabilityZone string
@@ -34,4 +36,15 @@ const (
 // It can be used for non-AZ-aware resources. The provided report will be placed under the AvailabilityZoneAny key.
 func InAnyAZ[T any](value T) map[AvailabilityZone]*T {
 	return map[AvailabilityZone]*T{AvailabilityZoneAny: &value}
+}
+
+// NormalizeAZ takes an AZ name as reported by an OpenStack service and safely casts it into the AvailabilityZone type.
+// If the provided raw value is not equal to any of the AZs known to Limes (from the second list), AvailabilityZoneUnknown will be returned.
+func NormalizeAZ(rawAZ string, allAZs []AvailabilityZone) AvailabilityZone {
+	az := AvailabilityZone(rawAZ)
+	if slices.Contains(allAZs, az) {
+		return az
+	} else {
+		return AvailabilityZoneUnknown
+	}
 }


### PR DESCRIPTION
This is a pattern that keeps appearing across liquids, esp. now that Limes has gotten stricter about rejecting unexpected AZ values.