### PR TITLE
liquid: rename ResourceTopology to Topology, add Topology field to RateInfo

### DIFF
--- a/liquid/quota.go
+++ b/liquid/quota.go
@@ -31,11 +31,11 @@ type ServiceQuotaRequest struct {
 // ResourceQuotaRequest contains new quotas for a single resource.
 // It appears in type ServiceQuotaRequest.
 type ResourceQuotaRequest struct {
-	// For FlatResourceTopology and AZAwareResourceTopology, this is the only field that is filled, and PerAZ will be nil.
-	// For AZSeparatedResourceTopology, this contains the sum of the quotas across all AZs (for compatibility purposes).
+	// For FlatTopology and AZAwareTopology, this is the only field that is filled, and PerAZ will be nil.
+	// For AZSeparatedTopology, this contains the sum of the quotas across all AZs (for compatibility purposes).
 	Quota uint64 `json:"quota"`
 
-	// PerAZ will only be filled for AZSeparatedResourceTopology.
+	// PerAZ will only be filled for AZSeparatedTopology.
 	PerAZ map[AvailabilityZone]AZResourceQuotaRequest `json:"perAZ,omitempty"`
 }
 

--- a/liquid/report_capacity.go
+++ b/liquid/report_capacity.go
@@ -41,7 +41,7 @@ type ResourceDemand struct {
 	OvercommitFactor OvercommitFactor `json:"overcommitFactor,omitempty"`
 
 	// The actual demand values are AZ-aware.
-	// The keys that can be expected in this map depend on the chosen ResourceTopology.
+	// The keys that can be expected in this map depend on the chosen Topology.
 	PerAZ map[AvailabilityZone]ResourceDemandInAZ `json:"perAZ"`
 }
 
@@ -77,8 +77,8 @@ type ServiceCapacityReport struct {
 // ResourceCapacityReport contains capacity data for a resource.
 // It appears in type ServiceCapacityReport.
 type ResourceCapacityReport struct {
-	// The keys that are allowed in this map depend on the chosen ResourceTopology.
-	// See documentation on ResourceTopology enum variants for details.
+	// The keys that are allowed in this map depend on the chosen Topology.
+	// See documentation on Topology enum variants for details.
 	PerAZ map[AvailabilityZone]*AZResourceCapacityReport `json:"perAZ"`
 }
 

--- a/liquid/report_usage.go
+++ b/liquid/report_usage.go
@@ -77,12 +77,12 @@ type ResourceUsageReport struct {
 	//   - If the project has no usage in this resource, Limes will hide this resource from project reports.
 	Forbidden bool `json:"forbidden"`
 
-	// This shall be null if and only if the resource is declared with "HasQuota = false" or with AZSeparatedResourceTopology.
+	// This shall be null if and only if the resource is declared with "HasQuota = false" or with AZSeparatedTopology.
 	// A negative value, usually -1, indicates "infinite quota" (i.e., the absence of a quota).
 	Quota *int64 `json:"quota,omitempty"`
 
-	// The keys that are allowed in this map depend on the chosen ResourceTopology.
-	// See documentation on ResourceTopology enum variants for details.
+	// The keys that are allowed in this map depend on the chosen Topology.
+	// See documentation on Topology enum variants for details.
 	//
 	// Tip: When filling this by starting from a non-AZ-aware usage number that is later broken down with AZ-aware data, use func PrepareForBreakdownInto.
 	PerAZ map[AvailabilityZone]*AZResourceUsageReport `json:"perAZ"`
@@ -102,7 +102,7 @@ type AZResourceUsageReport struct {
 	// It is not allowed to report 5 GiB as Usage in this situation, since the 50 GiB value is used when judging whether the Quota fits.
 	PhysicalUsage *uint64 `json:"physicalUsage,omitempty"`
 
-	// This shall be non-null if and only if the resource is declared with AZSeparatedResourceTopology.
+	// This shall be non-null if and only if the resource is declared with AZSeparatedTopology.
 	// A negative value, usually -1, indicates "infinite quota" (i.e., the absence of a quota).
 	Quota *int64 `json:"quota,omitempty"`
 
@@ -150,8 +150,8 @@ func (r *ResourceUsageReport) AddLocalizedUsage(az AvailabilityZone, usage uint6
 // RateUsageReport contains usage data for a rate in a single project.
 // It appears in type ServiceUsageReport.
 type RateUsageReport struct {
-	// The keys that are allowed in this map depend on the chosen ResourceTopology.
-	// See documentation on ResourceTopology enum variants for details.
+	// The keys that are allowed in this map depend on the chosen Topology.
+	// See documentation on Topology enum variants for details.
 	PerAZ map[AvailabilityZone]*AZRateUsageReport `json:"perAZ"`
 }
 


### PR DESCRIPTION
This is an oversight on my part. RateUsageReport.PerAZ is already documented as being AZ-aware in the same way as
ResourceUsageReport.PerAZ, so we need a topology declaration.

The name change from ResourceTopology to Topology is necessitated by Topology being relevant for rates, too, not just resources.