### PR TITLE
limes: add WasRenewed attribute to commitments

### DIFF
--- a/limes/resources/commitment.go
+++ b/limes/resources/commitment.go
@@ -59,6 +59,9 @@ type Commitment struct {
 	// NotifyOnConfirm can only be set if ConfirmBy is filled.
 	// Used to send a mail notification at commitment confirmation.
 	NotifyOnConfirm bool `json:"notify_on_confirm,omitempty"`
+	// WasRenewed indicates whether this commitment has been renewed.
+	// This means that a new commitment was created that will be confirmed when this commitment is set to expire.
+	WasRenewed bool `json:"was_renewed,omitempty"`
 }
 
 // CommitmentRequest is the API representation of a *new* commitment as requested by a user.


### PR DESCRIPTION
For sapcc/limes#674, we need this new attribute.
That PR currently suggests calling this field "WasExtended", but "WasRenewed" is more consistent with how this process is otherwise called in Limes.