### PR TITLE
[toplogy] sort errors by resource name and rate type

### DIFF
--- a/liquid/validation.go
+++ b/liquid/validation.go
@@ -46,17 +46,19 @@ func ValidateServiceInfo(srv ServiceInfo) error {
 }
 
 func validateServiceInfoImpl(srv ServiceInfo) (errs errorset.ErrorSet) {
-	for resName, resInfo := range srv.Resources {
-		if !resInfo.Topology.IsValid() {
-			errs.Addf(".Resources[%q] has invalid topology %q", resName, resInfo.Topology)
+	sortedResourceKeys := slices.Sorted(maps.Keys(srv.Resources))
+	for _, resName := range sortedResourceKeys {
+		if !srv.Resources[resName].Topology.IsValid() {
+			errs.Addf(".Resources[%q] has invalid topology %q", resName, srv.Resources[resName].Topology)
 		}
 	}
 
-	for rateName, rateInfo := range srv.Rates {
-		if !rateInfo.Topology.IsValid() {
-			errs.Addf(".Rates[%q] has invalid topology %q", rateName, rateInfo.Topology)
+	sortedRateInfos := slices.Sorted(maps.Keys(srv.Rates))
+	for _, rateName := range sortedRateInfos {
+		if !srv.Rates[rateName].Topology.IsValid() {
+			errs.Addf(".Rates[%q] has invalid topology %q", rateName, srv.Rates[rateName].Topology)
 		}
-		if !rateInfo.HasUsage {
+		if !srv.Rates[rateName].HasUsage {
 			errs.Addf(".Rates[%q] declared with HasUsage = false, but must be true", rateName)
 		}
 	}

--- a/liquid/validation.go
+++ b/liquid/validation.go
@@ -46,8 +46,7 @@ func ValidateServiceInfo(srv ServiceInfo) error {
 }
 
 func validateServiceInfoImpl(srv ServiceInfo) (errs errorset.ErrorSet) {
-	sortedResourceKeys := slices.Sorted(maps.Keys(srv.Resources))
-	for _, resName := range sortedResourceKeys {
+	for _, resName := range slices.Sorted(maps.Keys(srv.Resources)) {
 		if !srv.Resources[resName].Topology.IsValid() {
 			errs.Addf(".Resources[%q] has invalid topology %q", resName, srv.Resources[resName].Topology)
 		}

--- a/liquid/validation.go
+++ b/liquid/validation.go
@@ -52,8 +52,7 @@ func validateServiceInfoImpl(srv ServiceInfo) (errs errorset.ErrorSet) {
 		}
 	}
 
-	sortedRateInfos := slices.Sorted(maps.Keys(srv.Rates))
-	for _, rateName := range sortedRateInfos {
+	for _, rateName := range slices.Sorted(maps.Keys(srv.Rates)) {
 		if !srv.Rates[rateName].Topology.IsValid() {
 			errs.Addf(".Rates[%q] has invalid topology %q", rateName, srv.Rates[rateName].Topology)
 		}


### PR DESCRIPTION
I noticed that the limes tests are flaky within the pipeline.
The reason is that the toplogy tests check multiple invalid resource configurations and expects a given error result.
Without sorting the errors here the testsuit fails ocasionally.