### PR TITLE
liquid: adopt type Option as a replacement for pointers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/sapcc/go-api-declarations
 
 go 1.24
+
+require github.com/majewsky/gg v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/majewsky/gg v1.0.0 h1:d7ov8LJvsaNV/MpLkW5+xINap9JFxEs/GUJFUDNAPQk=
+github.com/majewsky/gg v1.0.0/go.mod h1:KC7qUlln1VBY90OE0jXMNjXW2b9B4jJ1heYQ08OzeAg=

--- a/liquid/quota.go
+++ b/liquid/quota.go
@@ -19,13 +19,15 @@
 
 package liquid
 
+import . "github.com/majewsky/gg/option"
+
 // ServiceQuotaRequest is the request payload format for PUT /v1/projects/:uuid/quota.
 type ServiceQuotaRequest struct {
 	Resources map[ResourceName]ResourceQuotaRequest `json:"resources"`
 
 	// Metadata about the project from Keystone.
 	// Only included if the ServiceInfo declared a need for it.
-	ProjectMetadata *ProjectMetadata `json:"projectMetadata,omitempty"`
+	ProjectMetadata Option[ProjectMetadata] `json:"projectMetadata,omitzero"`
 }
 
 // ResourceQuotaRequest contains new quotas for a single resource.

--- a/liquid/report_capacity.go
+++ b/liquid/report_capacity.go
@@ -18,6 +18,8 @@
 
 package liquid
 
+import . "github.com/majewsky/gg/option"
+
 // ServiceCapacityRequest is the request payload format for POST /v1/report-capacity.
 type ServiceCapacityRequest struct {
 	// All AZs known to Limes.
@@ -107,7 +109,7 @@ type AZResourceCapacityReport struct {
 	// If you can only fill this by summing up usage across all projects, don't; Limes can already do that.
 	// This is intended for consistency checks and to estimate how much usage cannot be attributed to OpenStack projects.
 	// For example, for compute, this would allow estimating how many VMs are not managed by Nova.
-	Usage *uint64 `json:"usage,omitempty"`
+	Usage Option[uint64] `json:"usage,omitzero"`
 
 	// Only filled if the resource is able to report subcapacities in a useful way.
 	Subcapacities []Subcapacity `json:"subcapacities,omitempty"`

--- a/liquid/report_usage.go
+++ b/liquid/report_usage.go
@@ -22,6 +22,8 @@ package liquid
 import (
 	"encoding/json"
 	"math/big"
+
+	. "github.com/majewsky/gg/option"
 )
 
 // ServiceUsageRequest is the request payload format for POST /v1/projects/:uuid/report-usage.
@@ -35,7 +37,7 @@ type ServiceUsageRequest struct {
 
 	// Metadata about the project from Keystone.
 	// Only included if the ServiceInfo declared a need for it.
-	ProjectMetadata *ProjectMetadata `json:"projectMetadata,omitempty"`
+	ProjectMetadata Option[ProjectMetadata] `json:"projectMetadata,omitzero"`
 
 	// The serialized state from the previous ServiceUsageReport received by Limes for this project, if any.
 	// Refer to the same field on type ServiceUsageReport for details.
@@ -79,7 +81,7 @@ type ResourceUsageReport struct {
 
 	// This shall be null if and only if the resource is declared with "HasQuota = false" or with AZSeparatedTopology.
 	// A negative value, usually -1, indicates "infinite quota" (i.e., the absence of a quota).
-	Quota *int64 `json:"quota,omitempty"`
+	Quota Option[int64] `json:"quota,omitzero"`
 
 	// The keys that are allowed in this map depend on the chosen Topology.
 	// See documentation on Topology enum variants for details.
@@ -100,11 +102,11 @@ type AZResourceUsageReport struct {
 	// For example, consider the Manila resource "share_capacity".
 	// If a project has 5 shares, each with 10 GiB size and each containing 1 GiB data, then Usage = 50 GiB and PhysicalUsage = 5 GiB.
 	// It is not allowed to report 5 GiB as Usage in this situation, since the 50 GiB value is used when judging whether the Quota fits.
-	PhysicalUsage *uint64 `json:"physicalUsage,omitempty"`
+	PhysicalUsage Option[uint64] `json:"physicalUsage,omitzero"`
 
 	// This shall be non-null if and only if the resource is declared with AZSeparatedTopology.
 	// A negative value, usually -1, indicates "infinite quota" (i.e., the absence of a quota).
-	Quota *int64 `json:"quota,omitempty"`
+	Quota Option[int64] `json:"quota,omitzero"`
 
 	// Only filled if the resource is able to report subresources for this usage in a useful way.
 	Subresources []Subresource `json:"subresources,omitempty"`
@@ -158,12 +160,13 @@ type RateUsageReport struct {
 // AZRateUsageReport contains usage data for a rate in a single project and AZ.
 // It appears in type RateUsageReport.
 type AZRateUsageReport struct {
-	// The amount of usage for this rate. Must be non-nil if the rate is declared with HasUsage = true.
+	// The amount of usage for this rate. Must be Some() and non-nil if the rate is declared with HasUsage = true.
+	// The value Some(nil) is forbidden.
 	//
 	// For a given rate, project and AZ, this value must only ever increase monotonically over time.
 	// If there is the possibility of counter resets or limited retention in the underlying data source, the liquid must add its own logic to guarantee monotonicity.
 	// A common strategy is to remember previous measurements in the SerializedState field of type ServiceUsageReport.
 	//
 	// This field is modeled as a bigint because network rates like "bytes transferred" may easily exceed the range of uint64 over time.
-	Usage *big.Int `json:"usage,omitempty"`
+	Usage Option[*big.Int] `json:"usage,omitzero"`
 }

--- a/liquid/subdivisions.go
+++ b/liquid/subdivisions.go
@@ -19,7 +19,11 @@
 
 package liquid
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	. "github.com/majewsky/gg/option"
+)
 
 // Subcapacity describes a distinct chunk of capacity for a resource within an AZ.
 // It appears in type AZResourceCapacityReport.
@@ -44,8 +48,8 @@ type Subcapacity struct {
 	// The amount of capacity in this subcapacity.
 	Capacity uint64 `json:"capacity"`
 
-	// How much of the Capacity is used, or null if no usage data is available.
-	Usage *uint64 `json:"usage,omitempty"`
+	// How much of the Capacity is used, or None if no usage data is available.
+	Usage Option[uint64] `json:"usage,omitzero"`
 
 	// Additional resource-specific attributes.
 	// This must be shaped like a map[string]any, but is typed as a raw JSON message.
@@ -60,7 +64,7 @@ type SubcapacityBuilder[A any] struct {
 	ID         string
 	Name       string
 	Capacity   uint64
-	Usage      *uint64
+	Usage      Option[uint64]
 	Attributes A
 }
 
@@ -92,9 +96,9 @@ type Subresource struct {
 	// Must be unique at least within its project.
 	Name string `json:"name,omitempty"`
 
-	// Must be null for counted resources (for which each subresource must be one of the things that is counted).
-	// Must be non-null for measured resources, and contain the subresource's size in terms of the resource's unit.
-	Usage *uint64 `json:"usage,omitempty"`
+	// Must be None for counted resources (for which each subresource must be one of the things that is counted).
+	// Must be Some for measured resources, and contain the subresource's size in terms of the resource's unit.
+	Usage Option[uint64] `json:"usage,omitzero"`
 
 	// Additional resource-specific attributes.
 	// This must be shaped like a map[string]any, but is typed as a raw JSON message.
@@ -108,7 +112,7 @@ type Subresource struct {
 type SubresourceBuilder[A any] struct {
 	ID         string
 	Name       string
-	Usage      *uint64
+	Usage      Option[uint64]
 	Attributes A
 }
 

--- a/liquid/validation.go
+++ b/liquid/validation.go
@@ -136,6 +136,7 @@ func validateCapacityReportImpl(report ServiceCapacityReport, req ServiceCapacit
 //   - Each rate must report usage exactly for those AZs that its declared topology requires:
 //     For FlatRateTopology, only AvailabilityZoneAny is allowed.
 //     For other topologies, all AZs in req.AllAZs must be present (and possibly AvailabilityZoneUnknown, but no others).
+//   - For rate usage values, the value Some(nil) is forbidden.
 //   - All metrics families declared in info.UsageMetricFamilies must be present (and no others).
 //   - The number of labels on each metric must match the declared label set.
 //
@@ -189,6 +190,14 @@ func validateUsageReportImpl(report ServiceUsageReport, req ServiceUsageRequest,
 			continue
 		}
 		errs.Add(validatePerAZAgainstTopology(rate.PerAZ, rateInfo.Topology, ".Rates", rateName, req.AllAZs))
+		for az, azRate := range rate.PerAZ {
+			usage, ok := azRate.Usage.Unpack()
+			if !ok {
+				errs.Addf("missing value for .Rates[%q].PerAZ[%q].Usage (rate was declared with HasUsage = true)", rateName, az)
+			} else if usage == nil {
+				errs.Addf("unexpected nil value in payload of .Rates[%q].PerAZ[%q].Usage", rateName, az)
+			}
+		}
 	}
 
 	return errs
@@ -251,10 +260,10 @@ func validatePerAZAgainstTopology[N ~string, V any](perAZ map[AvailabilityZone]V
 
 func validateQuotaAgainstTopology(report *ResourceUsageReport, hasQuota bool, topology Topology, name ResourceName, allAZs []AvailabilityZone) error {
 	// report.Quota shall be null if and only if the resource is declared with "HasQuota = false" or with AZSeparatedTopology
-	if report.Quota == nil && hasQuota && topology != AZSeparatedTopology {
+	if report.Quota.IsNone() && hasQuota && topology != AZSeparatedTopology {
 		return fmt.Errorf(".Resources[%q] has no quota reported on resource level, which is invalid for HasQuota = true and topology %q", name, topology)
 	}
-	if report.Quota != nil {
+	if report.Quota.IsSome() {
 		if !hasQuota {
 			return fmt.Errorf(".Resources[%q] has quota reported on resource level, which is invalid for HasQuota = false", name)
 		}
@@ -266,12 +275,12 @@ func validateQuotaAgainstTopology(report *ResourceUsageReport, hasQuota bool, to
 	var allAZsWithoutQuota []string
 	for _, az := range allAZs {
 		azReport, exists := report.PerAZ[az]
-		if !exists || azReport.Quota == nil {
+		if !exists || azReport.Quota.IsNone() {
 			allAZsWithoutQuota = append(allAZsWithoutQuota, string(az))
 			continue
 		}
 		// azReport.Quota shall be non-null if and only if the resource is declared with AZSeparatedTopology
-		if azReport.Quota != nil {
+		if azReport.Quota.IsSome() {
 			if !hasQuota {
 				return fmt.Errorf(".Resources[%q] has quota reported on AZ level, which is invalid for HasQuota = false", name)
 			}
@@ -286,7 +295,7 @@ func validateQuotaAgainstTopology(report *ResourceUsageReport, hasQuota bool, to
 			return fmt.Errorf(".Resources[%q] with topology %q is missing quota reports on the following AZs: %s", name, topology, strings.Join(allAZsWithoutQuota, ", "))
 		}
 		azReport, exists := report.PerAZ[AvailabilityZoneUnknown]
-		if exists && azReport.Quota != nil {
+		if exists && azReport.Quota.IsSome() {
 			return fmt.Errorf(".Resources[%q] reports quota in AZ %q, which is invalid for topology %q", name, AvailabilityZoneUnknown, topology)
 		}
 	}

--- a/liquid/validation_test.go
+++ b/liquid/validation_test.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"testing"
 
+	. "github.com/majewsky/gg/option"
+
 	"github.com/sapcc/go-api-declarations/internal/errorset"
 )
 
@@ -251,24 +253,24 @@ func TestValidateUsageReport(t *testing.T) {
 			// foo is missing
 			"bar": {
 				PerAZ: map[AvailabilityZone]*AZResourceUsageReport{
-					"az-one": {Usage: 42, Quota: p2i64(100)}, // AZ aware reporting on resource with flat topology
-					"az-two": {Usage: 42, Quota: p2i64(100)}, // Quota reporting on AZ level instead of resource level
+					"az-one": {Usage: 42, Quota: Some[int64](100)}, // AZ aware reporting on resource with flat topology
+					"az-two": {Usage: 42, Quota: Some[int64](100)}, // Quota reporting on AZ level instead of resource level
 				},
 			},
 			"baz": {
 				PerAZ: map[AvailabilityZone]*AZResourceUsageReport{
-					"az-one": {Usage: 42, Quota: p2i64(100)}, // Quota reporting on AZ level despite HasQuota = false
+					"az-one": {Usage: 42, Quota: Some[int64](100)}, // Quota reporting on AZ level despite HasQuota = false
 				},
 			},
 			"qux": {
-				Quota: p2i64(100), // Quota reporting on resource level instead of AZ level
+				Quota: Some[int64](100), // Quota reporting on resource level instead of AZ level
 				PerAZ: map[AvailabilityZone]*AZResourceUsageReport{
 					"any": {Usage: 42}, // Flat reporting for AZ aware resource
 				},
 			},
 			"quux": {
 				PerAZ: map[AvailabilityZone]*AZResourceUsageReport{
-					"az-one": {Quota: p2i64(100), Usage: 42}, // Partial AZ aware reporting, az-two is missing
+					"az-one": {Quota: Some[int64](100), Usage: 42}, // Partial AZ aware reporting, az-two is missing
 				},
 			},
 			"unknown": {
@@ -281,23 +283,23 @@ func TestValidateUsageReport(t *testing.T) {
 			// corge is missing
 			"grault": {
 				PerAZ: map[AvailabilityZone]*AZRateUsageReport{
-					"az-one": {Usage: big.NewInt(5)}, // AZ aware reporting on rate with flat topology
-					"az-two": {Usage: big.NewInt(5)},
+					"az-one": {Usage: Some(big.NewInt(5))}, // AZ aware reporting on rate with flat topology
+					"az-two": {Usage: Some(big.NewInt(5))},
 				},
 			},
 			"garply": {
 				PerAZ: map[AvailabilityZone]*AZRateUsageReport{
-					"any": {Usage: big.NewInt(5)}, // Flat reporting for AZ aware rate
+					"any": {Usage: Some(big.NewInt(5))}, // Flat reporting for AZ aware rate
 				},
 			},
 			"waldo": {
 				PerAZ: map[AvailabilityZone]*AZRateUsageReport{
-					"az-one": {Usage: big.NewInt(5)}, // Partial AZ aware reporting, az-two is missing
+					"az-one": {Usage: Some(big.NewInt(5))}, // Partial AZ aware reporting, az-two is missing
 				},
 			},
 			"unknown": {
 				PerAZ: map[AvailabilityZone]*AZRateUsageReport{
-					"any": {Usage: big.NewInt(5)}, // Report for rate which is not in ServiceInfo
+					"any": {Usage: Some(big.NewInt(5))}, // Report for rate which is not in ServiceInfo
 				},
 			},
 		},
@@ -335,60 +337,60 @@ func TestValidateUsageReport(t *testing.T) {
 		InfoVersion: 73,
 		Resources: map[ResourceName]*ResourceUsageReport{
 			"foo": {
-				Quota: p2i64(100),
+				Quota: Some[int64](100),
 				PerAZ: map[AvailabilityZone]*AZResourceUsageReport{
 					"az-one": {Usage: 42},
-					"az-two": {Usage: 42, Quota: p2i64(100)}, // Quota reporting on AZ level instead of resource level
+					"az-two": {Usage: 42, Quota: Some[int64](100)}, // Quota reporting on AZ level instead of resource level
 				},
 			},
 			"bar": {
-				Quota: p2i64(100),
+				Quota: Some[int64](100),
 				PerAZ: map[AvailabilityZone]*AZResourceUsageReport{
 					"any": {Usage: 42},
 				},
 			},
 			"baz": {
-				Quota: p2i64(100), // Quota reporting on resource level despite HasQuota = false
+				Quota: Some[int64](100), // Quota reporting on resource level despite HasQuota = false
 				PerAZ: map[AvailabilityZone]*AZResourceUsageReport{
-					"any": {Usage: 42, Quota: p2i64(100)}, // Quota reporting on AZ level despite HasQuota = false
+					"any": {Usage: 42, Quota: Some[int64](100)}, // Quota reporting on AZ level despite HasQuota = false
 				},
 			},
 			"qux": {
 				PerAZ: map[AvailabilityZone]*AZResourceUsageReport{
-					"unknown": {Usage: 42, Quota: p2i64(100)}, // Quota reporting in AZ "unknown"
-					"az-one":  {Usage: 42, Quota: p2i64(100)},
-					"az-two":  {Usage: 42, Quota: p2i64(100)},
+					"unknown": {Usage: 42, Quota: Some[int64](100)}, // Quota reporting in AZ "unknown"
+					"az-one":  {Usage: 42, Quota: Some[int64](100)},
+					"az-two":  {Usage: 42, Quota: Some[int64](100)},
 				},
 			},
 			"quux": {
 				PerAZ: map[AvailabilityZone]*AZResourceUsageReport{
-					"az-one": {Usage: 42, Quota: p2i64(100)},
-					"az-two": {Usage: 42, Quota: p2i64(100)},
+					"az-one": {Usage: 42, Quota: Some[int64](100)},
+					"az-two": {Usage: 42, Quota: Some[int64](100)},
 				},
 			},
 		},
 		Rates: map[RateName]*RateUsageReport{
 			"corge": {
 				PerAZ: map[AvailabilityZone]*AZRateUsageReport{
-					"az-one": {Usage: big.NewInt(5)},
-					"az-two": {Usage: big.NewInt(5)},
+					"az-one": {Usage: Some(big.NewInt(5))},
+					"az-two": {Usage: Some(big.NewInt(5))},
 				},
 			},
 			"grault": {
 				PerAZ: map[AvailabilityZone]*AZRateUsageReport{
-					"any": {Usage: big.NewInt(5)},
+					"any": {Usage: Some(big.NewInt(5))},
 				},
 			},
 			"garply": {
 				PerAZ: map[AvailabilityZone]*AZRateUsageReport{
-					"az-one": {Usage: big.NewInt(5)},
-					"az-two": {Usage: big.NewInt(5)},
+					"az-one": {Usage: Some(big.NewInt(5))},
+					"az-two": {Usage: Some(big.NewInt(5))},
 				},
 			},
 			"waldo": {
 				PerAZ: map[AvailabilityZone]*AZRateUsageReport{
-					"az-one": {Usage: big.NewInt(5)},
-					"az-two": {Usage: big.NewInt(5)},
+					"az-one": {Usage: None[*big.Int]()},    // Usage missing for rate with HasUsage = true
+					"az-two": {Usage: Some[*big.Int](nil)}, // Usage value not intact
 				},
 			},
 		},
@@ -401,6 +403,8 @@ func TestValidateUsageReport(t *testing.T) {
 		`.Resources["foo"] has quota reported on AZ level, which is invalid for topology "az-aware"`,
 		`.Resources["baz"] has quota reported on resource level, which is invalid for HasQuota = false`,
 		`.Resources["qux"] reports quota in AZ "unknown", which is invalid for topology "az-separated"`,
+		`missing value for .Rates["waldo"].PerAZ["az-one"].Usage (rate was declared with HasUsage = true)`,
+		`unexpected nil value in payload of .Rates["waldo"].PerAZ["az-two"].Usage`,
 	}
 	errs = validateUsageReportImpl(invalidServiceUsageReport2, serviceUsageRequest, serviceInfo)
 	assertErrorSet(t, errs, expectedErrStrings)
@@ -409,14 +413,14 @@ func TestValidateUsageReport(t *testing.T) {
 		InfoVersion: 73,
 		Resources: map[ResourceName]*ResourceUsageReport{
 			"foo": {
-				Quota: p2i64(100),
+				Quota: Some[int64](100),
 				PerAZ: map[AvailabilityZone]*AZResourceUsageReport{
 					"az-one": {Usage: 42},
 					"az-two": {Usage: 42},
 				},
 			},
 			"bar": {
-				Quota: p2i64(100),
+				Quota: Some[int64](100),
 				PerAZ: map[AvailabilityZone]*AZResourceUsageReport{
 					"any": {Usage: 42},
 				},
@@ -428,39 +432,39 @@ func TestValidateUsageReport(t *testing.T) {
 			},
 			"qux": {
 				PerAZ: map[AvailabilityZone]*AZResourceUsageReport{
-					"az-one": {Usage: 42, Quota: p2i64(100)},
-					"az-two": {Usage: 42, Quota: p2i64(100)},
+					"az-one": {Usage: 42, Quota: Some[int64](100)},
+					"az-two": {Usage: 42, Quota: Some[int64](100)},
 				},
 			},
 			"quux": {
 				PerAZ: map[AvailabilityZone]*AZResourceUsageReport{
-					"az-one": {Usage: 42, Quota: p2i64(100)},
-					"az-two": {Usage: 42, Quota: p2i64(100)},
+					"az-one": {Usage: 42, Quota: Some[int64](100)},
+					"az-two": {Usage: 42, Quota: Some[int64](100)},
 				},
 			},
 		},
 		Rates: map[RateName]*RateUsageReport{
 			"corge": {
 				PerAZ: map[AvailabilityZone]*AZRateUsageReport{
-					"az-one": {Usage: big.NewInt(5)},
-					"az-two": {Usage: big.NewInt(5)},
+					"az-one": {Usage: Some(big.NewInt(5))},
+					"az-two": {Usage: Some(big.NewInt(5))},
 				},
 			},
 			"grault": {
 				PerAZ: map[AvailabilityZone]*AZRateUsageReport{
-					"any": {Usage: big.NewInt(5)},
+					"any": {Usage: Some(big.NewInt(5))},
 				},
 			},
 			"garply": {
 				PerAZ: map[AvailabilityZone]*AZRateUsageReport{
-					"az-one": {Usage: big.NewInt(5)},
-					"az-two": {Usage: big.NewInt(5)},
+					"az-one": {Usage: Some(big.NewInt(5))},
+					"az-two": {Usage: Some(big.NewInt(5))},
 				},
 			},
 			"waldo": {
 				PerAZ: map[AvailabilityZone]*AZRateUsageReport{
-					"az-one": {Usage: big.NewInt(5)},
-					"az-two": {Usage: big.NewInt(5)},
+					"az-one": {Usage: Some(big.NewInt(5))},
+					"az-two": {Usage: Some(big.NewInt(5))},
 				},
 			},
 		},
@@ -491,9 +495,4 @@ func assertErrorSet(t *testing.T, actualErrorSet errorset.ErrorSet, expectedErrS
 			t.Errorf("unexpected error: %s", actualErrStr)
 		}
 	}
-}
-
-// p2i64 makes a "pointer to int64".
-func p2i64(val int64) *int64 {
-	return &val
 }


### PR DESCRIPTION
In a wildly unexpected move, this adds a **dependency** to go-api-declarations. \*audience gasps audibly\*

Jokes aside, this touches all places where pointer types are used to denote optionality throughout all LIQUID types. Places in which pointers are used for interior mutability are left as is.

`Rate.PerAZ[].Usage` is a bit of a weird case: Previously, we used nil to denote absence, so this becomes an `Option[]` type. But the payload type is still `*big.Int` because the API for big.Int only allows bigints to be passed by reference. A validation is added to forbid the value `Some(nil)`. At the same time, I'm adding a validation to forbid `None` for rates with `HasUsage = true`.