### PR TITLE
limesresources: add UUID field to commitments

### DIFF
--- a/limes/resources/commitment.go
+++ b/limes/resources/commitment.go
@@ -33,6 +33,7 @@ import (
 // Commitment is the API representation of an *existing* commitment as reported by Limes.
 type Commitment struct {
 	ID               int64                  `json:"id"`
+	UUID             string                 `json:"uuid"`
 	ServiceType      limes.ServiceType      `json:"service_type"`
 	ResourceName     ResourceName           `json:"resource_name"`
 	AvailabilityZone limes.AvailabilityZone `json:"availability_zone"`


### PR DESCRIPTION
It is a historical mistake of mine that we exposed numerical IDs on commitments in the first place. We should have UUIDs here to avoid exposing the number of commitments to non-privileged users, and as defense in depth against enumeration attacks.

Because commitments of some sort will start appearing in LIQUID soon, I want to right this wrong before it seeps into the LIQUID API. LIQUID will only ever refer to commitments by UUID, and the Limes v2 API will also move to only using UUIDs. The v1 API will show both identifiers to aid in the migration.

The Limes side of this is sapcc/limes#730, but this side needs to be merged first.