### PR TITLE
liquid: add commitment acceptance delegation

### DIFF
--- a/liquid/commitment.go
+++ b/liquid/commitment.go
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package liquid
+
+import (
+	"time"
+
+	. "github.com/majewsky/gg/option"
+)
+
+// CommitmentChangeRequest is the request payload format for POST /v1/change-commitments.
+type CommitmentChangeRequest struct {
+	AZ AvailabilityZone `json:"az"`
+
+	// On the first level, the commitment changeset is grouped by project.
+	//
+	// Changesets may span over multiple projects e.g. when moving commitments from one project to another.
+	// In this case, the changeset will show the commitment as being deleted in the source project, and as being created in the target project.
+	ByProject map[ProjectUUID]ProjectCommitmentChangeset `json:"byProject"`
+
+	// Whether Limes allows the liquid to confirm (or deny) this changeset.
+	// If true, Limes will only apply the changeset in its database if the response from the liquid is positive.
+	// If false, Limes has already applied the changeset in its database, and is only notifying the liquid about what happened.
+	//
+	// Examples for ExpectsConfirmation = true include commitments moving into the "confirmed" status, or conversion of commitments between resources.
+	// Examples for ExpectsConfirmation = false include commitments being split or moving into the "expired" status.
+	ExpectsConfirmation bool `json:"expectsConfirmation"`
+}
+
+// CommitmentChangeResponse is the response payload format for POST /v1/change-commitments.
+type CommitmentChangeResponse struct {
+	// If ExpectsConfirmation was true, this field shall be empty if the changeset is confirmed, or contain a human-readable error message if the changeset was rejected.
+	// If ExpectsConfirmation was false, Limes will ignore this field (or, at most, log it silently).
+	RejectionReason string `json:"rejectionReason,omitempty"`
+}
+
+// ProjectCommitmentChangeset appears in type CommitmentChangeRequest.
+// It contains all commitments that are part of a single atomic changeset that belong to a specific project in a specific AZ.
+type ProjectCommitmentChangeset struct {
+	// Metadata about the project from Keystone.
+	// Only included if the ServiceInfo declared a need for it.
+	ProjectMetadata Option[ProjectMetadata] `json:"projectMetadata,omitzero"`
+
+	// On the second level, the commitment changeset is grouped by resource.
+	//
+	// Changesets may span over multiple resources when converting commitments for one resource into commitments for another resource.
+	// In this case, the changeset will show the original commitment being deleted in one resource, and a new commitment being created in another.
+	ByResource map[ResourceName]ResourceCommitmentChangeset `json:"byResource"`
+}
+
+// ResourceCommitmentChangeset appears in type CommitmentChangeRequest.
+// It contains all commitments that are part of a single atomic changeset that belong to a given resource within a specific project and AZ.
+type ResourceCommitmentChangeset struct {
+	// The sum of all commitments for the given resource, project and AZ before and after applying the proposed commitment changeset.
+	//
+	// For example, if this changeset shows a commitment with Amount = 6 as being created, and one with Amount = 9 as being deleted,
+	// and also there are several other commitments with a total Amount = 100 that the changeset does not touch,
+	// then we will have TotalCommittedBefore = 109 and TotalCommittedAfter = 106.
+	TotalCommittedBefore uint64 `json:"totalCommittedBefore"`
+	TotalCommittedAfter  uint64 `json:"totalCommittedAfter"`
+
+	// A commitment changeset may contain multiple commitments for a single resource within the same project.
+	// For example, when a commitment is split into two parts, the changeset will show the original commitment being deleted and two new commitments being created.
+	Commitments []Commitment `json:"commitments"`
+}
+
+// Commitment appears in type CommitmentChangeRequest.
+//
+// The commitment is located in a certain project and applies to a certain resource within a certain AZ.
+// These metadata are implied by where the commitment is found within type CommitmentChangeRequest.
+type Commitment struct {
+	// The same UUID may appear multiple times within the same changeset for one specific circumstance:
+	// If a commitment moves between projects, it will appear as being deleted in the source project and again as being created in the target project.
+	UUID string `json:"uuid"`
+
+	// These two status fields communicate one of three possibilities:
+	//   - If OldStatus.IsNone() and NewStatus.IsSome(), the commitment is being created (or moved to this location).
+	//   - If OldStatus.IsSome() and NewStatus.IsNone(), the commitment is being deleted (or moved away from this location).
+	//   - If OldStatus.IsSome() and NewStatus.IsSome(), the commitment is only changing its status (e.g. from "active" to "expired" when ExpiresAt has passed).
+	OldStatus Option[CommitmentStatus] `json:"oldStatus"`
+	NewStatus Option[CommitmentStatus] `json:"newStatus"`
+
+	Amount uint64 `json:"amount"`
+
+	// For commitments in status "planned", this field contains the point in time in the future when the user wants for it to move into status "confirmed".
+	// If confirmation is not possible by that point in time, the commitment will move into status "pending" until it can be confirmed.
+	//
+	// For all other status values, this field contains the point in time when the status transitioned from "active" to "pending",
+	// or None() if the commitment was created for immediate confirmation and therefore started in status "pending".
+	ConfirmBy Option[time.Time] `json:"confirmBy,omitzero"`
+
+	// This field contains the point in time when the commitment moves into status "expired", unless it is deleted or moves into status "superseded" first.
+	ExpiresAt time.Time `json:"expiresAt,omitzero"`
+}
+
+// CommitmentStatus is an enum containing the various lifecycle states of type Commitment.
+type CommitmentStatus string
+
+const (
+	// CommitmentStatusPlanned means that the commitment has a ConfirmBy date in the future.
+	// Planned commitments are used to notify the cloud about future resource demand.
+	CommitmentStatusPlanned CommitmentStatus = "planned"
+	// CommitmentStatusPending means that the commitment has a ConfirmBy date in the past, but the cloud has not confirmed it yet.
+	// Pending commitments usually occur when there is not enough capacity to cover all current resource demands.
+	CommitmentStatusPending CommitmentStatus = "pending"
+	// CommitmentStatusConfirmed means that the commitment has been confirmed and is being honored by the cloud.
+	// Confirmed commitments represent current resource demand that the cloud is able to guarantee.
+	CommitmentStatusConfirmed CommitmentStatus = "confirmed"
+	// CommitmentStatusSuperseded means that the commitment is no longer being honored by the cloud because it has been replaced by other commitments.
+	// For example, when splitting a commitment into two halves, the new commitments will have the same status as the old commitment, and the old commitment will move into status "superseded".
+	CommitmentStatusSuperseded CommitmentStatus = "superseded"
+	// CommitmentStatusExpired means that the commitment is no longer being honored by the cloud because its lifetime has expired.
+	// Expired commitments can be renewed by the user manually, but that involves creating a new commitment separately, such that ConfirmBy of the new commitment is equal to ExpiresAt of the old commitment.
+	CommitmentStatusExpired CommitmentStatus = "expired"
+)

--- a/liquid/doc.go
+++ b/liquid/doc.go
@@ -48,6 +48,22 @@
 // Capacity and usage may be AZ-aware, in which case one value will be reported per availability zone (AZ).
 // Quota is only optionally modelled as AZ-aware since there are no OpenStack services that support AZ-aware quota at this time.
 //
+// # Resource commitments
+//
+// If configured in Limes, resources may allow for commitments to be created.
+// Within the context of LIQUID, a commitment represents a guarantee by the cloud platform that a specific project can provision a guaranteed minimum amount of a resource.
+// For example, if a project currently has a usage of 8 and for the resource "network/routers", taking out a commitment for 10 routers would mean that the cloud guarantees that this project can provision 10 - 8 = 2 additional routers in the future.
+//
+// Each commitments refers to some amount of a resource being reserved for a specific project in a certain AZ.
+// Multiple commitments can be active at the same time for the same project, resource and AZ, in which case the guaranteed-deployable amount of resource will be equal to the sum of all active commitments.
+//
+// By default, resources in LIQUID do not care about commitments at all, and Limes will manage commitments purely based on the numbers provided by the liquid:
+// Commitments will be approved as long as there is enough unused capacity to cover the unused part of the commitment.
+// And quota will be given out in a way that seeks to guarantee the usability of existing commitments.
+//
+// If a liquid has access to a better way of guaranteeing commitments (e.g. by making explicit reservations in its service), it can take over commitment acceptance.
+// For resources with this behavior, Limes will present all changes to commitments to the liquid for approval.
+//
 // # Inside a rate: Usage
 //
 // Rates are measurements that only ever increase over time, similar to the Prometheus metric type "counter".
@@ -112,15 +128,26 @@
 //   - The request body payload must be of type ServiceQuotaRequest.
 //   - On success, the response body shall be empty and status 204 (No Content) shall be returned.
 //
+// # Endpoint: POST /v1/change-commitments
+//
+// Notifies the liquid about changes to commitments that it is interested in.
+// Commitments for different projects and different resources may be batched together if they are all part of the same atomic change.
+//   - The request body payload must be of type CommitmentChangeRequest.
+//   - On success, the response body payload must be of type CommitmentChangeResponse.
+//
 // [Limes]: https://github.com/sapcc/limes
 // [OpenMetrics format]: https://github.com/OpenObservability/OpenMetrics/blob/master/specification/OpenMetrics.md
 // [Prometheus]: https://prometheus.io/
 package liquid
 
+// ProjectUUID identifies a project known to Keystone.
+// This type is used to distinguish project UUIDs from other types of string values in structs and function signatures.
+type ProjectUUID string
+
 // ResourceName identifies a resource within a service.
-// This type is used to distinguish resource names from other types of string values in function signatures.
+// This type is used to distinguish resource names from other types of string values in structs and function signatures.
 type ResourceName string
 
 // RateName identifies a rate within a service.
-// This type is used to distinguish rate names from other types of string values in function signatures.
+// This type is used to distinguish rate names from other types of string values in structs and function signatures.
 type RateName string

--- a/liquid/info.go
+++ b/liquid/info.go
@@ -37,6 +37,9 @@ type ServiceInfo struct {
 
 	// Whether Limes needs to include the ProjectMetadata field in its quota update requests.
 	QuotaUpdateNeedsProjectMetadata bool `json:"quotaUpdateNeedsProjectMetadata,omitempty"`
+
+	// Whether Limes needs to include the ProjectMetadata field in its commitment handling requests.
+	CommitmentHandlingNeedsProjectMetadata bool `json:"commitmentHandlingNeedsProjectMetadata,omitempty"`
 }
 
 // ResourceInfo describes a resource that a liquid's service provides.
@@ -60,6 +63,11 @@ type ResourceInfo struct {
 	// If false, only usage is reported on the project level.
 	// Limes will abstain from maintaining quota on such resources.
 	HasQuota bool `json:"hasQuota"`
+
+	// Whether the liquid takes responsibility for reviewing changes to commitments for this resource.
+	// If false, Limes will handle commitments on this resource on its own without involving the liquid.
+	// If true, the liquid needs to be prepared to handle commitment-related requests for this resource.
+	HandlesCommitments bool `json:"handlesCommitments"`
 
 	// Additional resource-specific attributes.
 	// For example, a resource for baremetal nodes of a certain flavor might report flavor attributes like the CPU and RAM size here, instead of on subcapacities and subresources, to avoid repetition.


### PR DESCRIPTION
This fixes some weird naming in the Limes v1 API that I intend to also change in this way in the v2 API:

- CommitmentState is renamed to CommitmentStatus to match CommitmentTransferStatus.
- The state "active" is renamed to "confirmed" to match ConfirmBy.

**Note:** Please do not merge on your own even if there are enough approvals; wait for me to do it. This needs alignment with the Workload Management team.