### PR TITLE
run `modernize -fix ./...`

### DIFF
--- a/cadf/event.go
+++ b/cadf/event.go
@@ -34,7 +34,7 @@ type Event struct {
 	Outcome Outcome `json:"outcome"`
 
 	// Standard response for successful HTTP requests
-	Reason Reason `json:"reason,omitempty"`
+	Reason Reason `json:"reason"`
 
 	// CADF component that contains the RESOURCE
 	// that initiated, originated, or instigated the event's

--- a/limes/rates/window.go
+++ b/limes/rates/window.go
@@ -94,7 +94,7 @@ func (w Window) MarshalJSON() ([]byte, error) {
 	if repr == "" {
 		return nil, fmt.Errorf("unrepresentable window size: %d ns", uint64(w))
 	}
-	return []byte(fmt.Sprintf("%q", repr)), nil
+	return fmt.Appendf(nil, "%q", repr), nil
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface.

--- a/limes/resources/commitment.go
+++ b/limes/resources/commitment.go
@@ -38,7 +38,7 @@ type Commitment struct {
 	ConfirmBy *limes.UnixEncodedTime `json:"confirm_by,omitempty"`
 	// ConfirmedAt is only filled after the commitment was confirmed.
 	ConfirmedAt *limes.UnixEncodedTime `json:"confirmed_at,omitempty"`
-	ExpiresAt   limes.UnixEncodedTime  `json:"expires_at,omitempty"`
+	ExpiresAt   limes.UnixEncodedTime  `json:"expires_at"`
 	// TransferStatus and TransferToken are only filled while the commitment is marked for transfer.
 	TransferStatus CommitmentTransferStatus `json:"transfer_status,omitempty"`
 	TransferToken  *string                  `json:"transfer_token,omitempty"`
@@ -109,7 +109,7 @@ var cdTokenRx = regexp.MustCompile(`^([0-9]*)\s*(second|minute|hour|day|month|ye
 // Acceptable inputs include "5 hours" and "1year,2 \t months,  3days".
 func ParseCommitmentDuration(input string) (CommitmentDuration, error) {
 	var result CommitmentDuration
-	for _, field := range strings.Split(input, ",") {
+	for field := range strings.SplitSeq(input, ",") {
 		field = strings.TrimSpace(field)
 		if field == "" {
 			continue

--- a/limes/resources/report_project.go
+++ b/limes/resources/report_project.go
@@ -62,7 +62,7 @@ type ProjectAZResourceReport struct {
 type HistoricalReport struct {
 	MinUsage uint64             `json:"min_usage,omitempty"`
 	MaxUsage uint64             `json:"max_usage,omitempty"`
-	Duration CommitmentDuration `json:"duration,omitempty"`
+	Duration CommitmentDuration `json:"duration"`
 }
 
 // ProjectServiceReports provides fast lookup of services using a map, but serializes


### PR DESCRIPTION
Most of these are removing ineffective `omitempty` on struct members. For context, structs can never match the condition behind `omitempty`, as explained on the docs of [`json.Marshal`](https://pkg.go.dev/encoding/json#Marshal):

> The "omitempty" option specifies that the field should be omitted from the encoding if the field has an empty value, defined as false, 0, a nil pointer, a nil interface value, and any array, slice, map, or string of length zero. 