### PR TITLE
liquid: fix type errors in commitment API

### DIFF
--- a/liquid/commitment.go
+++ b/liquid/commitment.go
@@ -102,7 +102,7 @@ type Commitment struct {
 	ConfirmBy Option[time.Time] `json:"confirmBy,omitzero"`
 
 	// This field contains the point in time when the commitment moves into status "expired", unless it is deleted or moves into status "superseded" first.
-	ExpiresAt time.Time `json:"expiresAt,omitzero"`
+	ExpiresAt time.Time `json:"expiresAt"`
 }
 
 // CommitmentStatus is an enum containing the various lifecycle states of type Commitment.


### PR DESCRIPTION
Goes to show that you can look at a change a billion times, but the compiler will always be better at finding type mismatches once you actually try and use the type.

- ServiceInfo.Version is an int64 (to match `time.Now().Unix()`, so CommitmentChangeRequest.InfoVersion needs to be the same type.
- While double-checking the other types, I saw that `ExpiresAt` has `omitzero` even though it must always be set and is not an Option type.