### PR TITLE
liquid: add validation for resource/rate/AZ names, reserve pseudo-AZ "total"

### DIFF
--- a/liquid/availability_zone.go
+++ b/liquid/availability_zone.go
@@ -14,7 +14,21 @@ const (
 	AvailabilityZoneAny AvailabilityZone = "any"
 	// AvailabilityZoneUnknown marks values that are bound to an unknown AZ.
 	AvailabilityZoneUnknown AvailabilityZone = "unknown"
+	// AvailabilityZoneTotal is reserved for situations where AZ-aware values need to be stored and it is useful to store the sum across all AZs alongside the AZ-aware values.
+	// For example, usage for a project resource could be stored as {"az-one": 10, "az-two": 5, "total": 15}.
+	AvailabilityZoneTotal AvailabilityZone = "total"
 )
+
+// IsReal returns whether the given AZ value looks like it refers to a real AZ.
+// False is returned for the empty string, as well as all of the special values enumerated above.
+func (az AvailabilityZone) IsReal() bool {
+	switch az {
+	case "", AvailabilityZoneAny, AvailabilityZoneUnknown, AvailabilityZoneTotal:
+		return false
+	default:
+		return true
+	}
+}
 
 // InAnyAZ is a convenience constructor for the PerAZ fields of ResourceCapacityReport and ResourceUsageReport.
 // It can be used for non-AZ-aware resources. The provided report will be placed under the AvailabilityZoneAny key.

--- a/liquid/doc.go
+++ b/liquid/doc.go
@@ -148,8 +148,40 @@ type ProjectUUID string
 
 // ResourceName identifies a resource within a service.
 // This type is used to distinguish resource names from other types of string values in structs and function signatures.
+//
+// The following conventions apply to resource names:
+//   - Countable resources are named in the plural (e.g. "floating_ips" instead of "floating_ip").
+//   - Measured resources are named in the singular (e.g. "ram" or "capacity").
+//   - Resource names are commonly written in snake_case.
+//
+// If other identifiers are embedded in a resource name (e.g. volume type names or flavor names), dashes and dots are also permitted.
+// See func IsValid for more information.
 type ResourceName string
+
+// IsValid returns whether this string is a valid resource name.
+//
+// Resource names allow ASCII letters, digits, underscores, hyphens and dots.
+// The first character must be an alphanumeric character.
+func (n ResourceName) IsValid() bool {
+	return isValidIdentifier(n)
+}
 
 // RateName identifies a rate within a service.
 // This type is used to distinguish rate names from other types of string values in structs and function signatures.
+//
+// The following conventions apply to rate names:
+//   - Countable rates are named in the plural (e.g. "image_deletions" instead of "image_deletion" or even "delete_image").
+//   - Measured rates are named in the singular (e.g. "outbound_transfer").
+//   - Rate names are commonly written in snake_case.
+//
+// If other identifiers are embedded in a rate name (e.g. volume type names or flavor names), dashes and dots are also permitted.
+// See func IsValid for more information.
 type RateName string
+
+// IsValid returns whether this string is a valid rate name.
+//
+// Rate names allow ASCII letters, digits, underscores, hyphens and dots.
+// The first character must be an alphanumeric character.
+func (n RateName) IsValid() bool {
+	return isValidIdentifier(n)
+}

--- a/liquid/validation_test.go
+++ b/liquid/validation_test.go
@@ -95,23 +95,27 @@ var serviceInfo = ServiceInfo{
 func TestValidateServiceInfo(t *testing.T) {
 	invalidServiceInfo := ServiceInfo{
 		Resources: map[ResourceName]ResourceInfo{
-			"foo": {}, // Topology is missing
-			"bar": {Topology: "InvalidTopology"},
-			"baz": {Topology: AZSeparatedTopology},
+			"foo":         {}, // Topology is missing
+			"bar":         {Topology: "InvalidTopology"},
+			"baz":         {Topology: AZSeparatedTopology},
+			"foo+private": {Topology: FlatTopology}, // Invalid name
 		},
 		Rates: map[RateName]RateInfo{
-			"corge":  {HasUsage: true}, // Topology is missing
-			"grault": {HasUsage: true, Topology: "InvalidTopology"},
-			"garply": {HasUsage: false, Topology: AZSeparatedTopology}, // HasUsage = false is not allowed
-			"waldo":  {HasUsage: true, Topology: AZSeparatedTopology},
+			"corge":      {HasUsage: true}, // Topology is missing
+			"grault":     {HasUsage: true, Topology: "InvalidTopology"},
+			"garply":     {HasUsage: false, Topology: AZSeparatedTopology}, // HasUsage = false is not allowed
+			"waldo":      {HasUsage: true, Topology: AZSeparatedTopology},
+			"foo/create": {HasUsage: true, Topology: FlatTopology}, // Invalid name
 		},
 	}
 	expectedErrStrings := []string{
 		`.Resources["foo"] has invalid topology ""`,
 		`.Resources["bar"] has invalid topology "InvalidTopology"`,
+		`.Resources["foo+private"] has invalid name (must match /^[a-zA-Z][a-zA-Z0-9._-]*$/)`,
 		`.Rates["corge"] has invalid topology ""`,
 		`.Rates["grault"] has invalid topology "InvalidTopology"`,
 		`.Rates["garply"] declared with HasUsage = false, but must be true`,
+		`.Rates["foo/create"] has invalid name (must match /^[a-zA-Z][a-zA-Z0-9._-]*$/)`,
 	}
 	errs := validateServiceInfoImpl(invalidServiceInfo)
 	assertErrorSet(t, errs, expectedErrStrings)


### PR DESCRIPTION
### add ResourceName.IsValid(), RateName.IsValid()

Because the "service/resource" notation for resources is well-established, and the "service/resource/az" notation for AZ resources is establishing itself, I would like to explicitly forbid slashes from occurring in service types and resource names.

If we're doing a validation at all, I feel like we can be slightly more restrictive than just "no slashes", though, so this commit establishes a rule that resource names and rate names must basically look like C identifiers, except that dashes and dots are also allowed. This matches all existing resource names in production.

For rate names, the situation is a bit weirder, because we have two competing precedents:

- For rates reporting usage (currently only Ceph), rate names look like resource names, e.g. `attachment_size` or `recipients`.
- For rates with limits (currently only Swift in QA), rate names look like CADF actions, e.g.  `account/container:write`.

The second format here has the significant disadvantage of allowing (and even requiring) slashes in the name, which is specifically what I want to forbid. I choose to go with the first format here, so rates following the second format will have to be renamed. This ought to be fine since the existing Limes integration in sapcc/openstack-rate-limit-middleware is not actually used at this point. If it is to be used, we can expose the CADF action name as a separate field on the Limes API.

### add AvailabilityZoneTotal, AvailabilityZone.IsReal()

This reserves the AZ name "total" for aggregations stored in the Limes DB. We are currently storing this on the resource level, rather on the AZ resource level, but I have a hunch that several queries can be simplified by storing both on the same level.