### PR TITLE
Extensions to the liquid commitment delegation

### DIFF
--- a/liquid/doc.go
+++ b/liquid/doc.go
@@ -146,6 +146,10 @@ package liquid
 // This type is used to distinguish project UUIDs from other types of string values in structs and function signatures.
 type ProjectUUID string
 
+// CommitmentUUID identifies a project commitment within a liquid.
+// This type is used to distinguish commitment UUIDs from other types of string values in structs and function signatures.
+type CommitmentUUID string
+
 // ResourceName identifies a resource within a service.
 // This type is used to distinguish resource names from other types of string values in structs and function signatures.
 //


### PR DESCRIPTION
The `Commitment.UUID` type change is mainly a style-question. I am happy to remove this, if we want to stick to the local definition in `datamodel` of limes.