### PR TITLE
liquid: add Clone() methods to all non-trivial types

### DIFF
--- a/internal/clone/clone.go
+++ b/internal/clone/clone.go
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+// Package clone contains helper functions for implementing deep clones.
+package clone
+
+type Cloneable[Self any] interface {
+	Clone() Self
+}
+
+// MapRecursively clones a map containing Cloneable values by recursing into Clone() of those values.
+func MapRecursively[M ~map[K]V, K comparable, V Cloneable[V]](in M) M {
+	out := make(M, len(in))
+	for k, v := range in {
+		out[k] = v.Clone()
+	}
+	return out
+}
+
+// MapOfPointersRecursively clones a map containing pointers to Cloneable values by recursing into Clone() of those values.
+func MapOfPointersRecursively[M ~map[K]*V, K comparable, V Cloneable[V]](in M) M {
+	out := make(M, len(in))
+	for k, v := range in {
+		cloned := (*v).Clone()
+		out[k] = &cloned
+	}
+	return out
+}
+
+// SliceRecursively clones a slice containing Cloneable values by recursing into Clone() of those values.
+func SliceRecursively[S ~[]V, V Cloneable[V]](in S) S {
+	out := make(S, len(in))
+	for idx, v := range in {
+		out[idx] = v.Clone()
+	}
+	return out
+}
+
+// MapOfSlicesRecursively clones a map containing slices of Cloneable values.
+func MapOfSlicesRecursively[M ~map[K]S, K comparable, S ~[]V, V Cloneable[V]](in M) M {
+	out := make(M, len(in))
+	for k, s := range in {
+		out[k] = SliceRecursively(s)
+	}
+	return out
+}

--- a/internal/testhelper/clone.go
+++ b/internal/testhelper/clone.go
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package testhelper
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// CheckFullySeparate tests whether the left-hand side and right-hand side values
+// are fully separate from each other. This test fails if manipulating any part
+// of one value can have an effect on the other value through sharing a
+// contained pointer (or map or slice).
+func CheckFullySeparate[V any](t *testing.T, lhs, rhs V) {
+	t.Helper()
+	refs := make(map[uintptr]any)
+	walkByReference(reflect.ValueOf(lhs), func(v reflect.Value) {
+		refs[uintptr(v.UnsafePointer())] = v.Interface()
+	})
+
+	walkByReference(reflect.ValueOf(rhs), func(v reflect.Value) {
+		value, exists := refs[uintptr(v.UnsafePointer())]
+		if exists {
+			t.Errorf("CheckFullySeparate found a reused value: %#v", value)
+		}
+	})
+}
+
+// Walks through `v` and calls `action` once for every pointer-ish thing in it
+// that can be modified in-place (i.e. every chan, func, map, pointer or slice).
+func walkByReference(v reflect.Value, action func(reflect.Value)) {
+	switch v.Kind() {
+	case reflect.Chan, reflect.Func:
+		action(v)
+
+	case reflect.Pointer:
+		action(v)
+		fallthrough
+	case reflect.Interface:
+		// NOTE: cannot call `action` for reflect.Interface because this kind does not allow v.UnsafePointer()
+		//       (but that's okay because we will call `action` on v.Elem() in the next recursion level if necessary)
+		walkByReference(v.Elem(), action)
+
+	case reflect.Slice:
+		action(v)
+		fallthrough
+	case reflect.Array:
+		// NOTE: cannot call `action` for reflect.Array because this kind does not allow v.UnsafePointer()
+		//       (but that's okay because a fixed-size array member of e.g. a struct does not represent its own allocation)
+		for idx := range v.Len() {
+			walkByReference(v.Index(idx), action)
+		}
+
+	case reflect.Map:
+		action(v)
+		for _, key := range v.MapKeys() {
+			walkByReference(key, action)
+			walkByReference(v.MapIndex(key), action)
+		}
+
+	case reflect.Struct:
+		// trying to walk through struct types with unexported fields would break;
+		// use domain knowledge instead for the few relevant cases
+		t := v.Type()
+		switch {
+		case t.PkgPath() == "github.com/majewsky/gg/option" && strings.HasPrefix(t.Name(), "Option["):
+			// Option[T] can be traversed with the Unpack() method
+			retvals := v.MethodByName("Unpack").Call(nil) // value, ok := optionalValue.Unpack()
+			if retvals[1].Interface().(bool) == true {    // if ok {
+				walkByReference(retvals[0], action) // walkByReference(value, action)
+			}
+			return
+		case t.PkgPath() == "time" && t.Name() == "Time":
+			// time.Time does not have any pointer-ish values inside of it
+			return
+		case t.PkgPath() == "math/big" && t.Name() == "Int":
+			// *big.Int DOES have pointer-ish values inside of it (specifically, a growable slice of words),
+			// but its API ensures that two *big.Int values with distinct pointers also hold distinct slices;
+			// since we already checked the outer pointer before coming here, we do not need to check further
+			return
+		}
+
+		for idx := range v.NumField() {
+			walkByReference(v.Field(idx), action)
+		}
+	}
+}

--- a/internal/testhelper/clone.go
+++ b/internal/testhelper/clone.go
@@ -4,6 +4,7 @@
 package testhelper
 
 import (
+	"go/constant"
 	"reflect"
 	"strings"
 	"testing"
@@ -68,14 +69,14 @@ func walkByReference(v reflect.Value, action func(reflect.Value)) {
 		case t.PkgPath() == "github.com/majewsky/gg/option" && strings.HasPrefix(t.Name(), "Option["):
 			// Option[T] can be traversed with the Unpack() method
 			retvals := v.MethodByName("Unpack").Call(nil) // value, ok := optionalValue.Unpack()
-			if retvals[1].Interface().(bool) == true {    // if ok {
+			if retvals[1].Interface().(bool) {            // if ok {
 				walkByReference(retvals[0], action) // walkByReference(value, action)
 			}
 			return
 		case t.PkgPath() == "time" && t.Name() == "Time":
 			// time.Time does not have any pointer-ish values inside of it
 			return
-		case t.PkgPath() == "math/big" && t.Name() == "Int":
+		case t.PkgPath() == "math/big" && t.Name() == constant.Int.String():
 			// *big.Int DOES have pointer-ish values inside of it (specifically, a growable slice of words),
 			// but its API ensures that two *big.Int values with distinct pointers also hold distinct slices;
 			// since we already checked the outer pointer before coming here, we do not need to check further

--- a/liquid/commitment.go
+++ b/liquid/commitment.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	. "github.com/majewsky/gg/option"
+	"github.com/sapcc/go-api-declarations/internal/clone"
 )
 
 // CommitmentChangeRequest is the request payload format for POST /v1/change-commitments.
@@ -30,6 +31,13 @@ type CommitmentChangeRequest struct {
 	ByProject map[ProjectUUID]ProjectCommitmentChangeset `json:"byProject"`
 }
 
+// Clone returns a deep copy of the given CommitmentChangeRequest.
+func (r CommitmentChangeRequest) Clone() CommitmentChangeRequest {
+	cloned := r
+	cloned.ByProject = clone.MapRecursively(r.ByProject)
+	return cloned
+}
+
 // CommitmentChangeResponse is the response payload format for POST /v1/change-commitments.
 type CommitmentChangeResponse struct {
 	// If req.RequiresConfirmation() was true, this field shall be empty if the changeset is confirmed, or contain a human-readable error message if the changeset was rejected.
@@ -46,6 +54,13 @@ type CommitmentChangeResponse struct {
 	RetryAt Option[time.Time] `json:"retryAt,omitzero"`
 }
 
+// Clone returns a deep copy of the given CommitmentChangeResponse.
+func (r CommitmentChangeResponse) Clone() CommitmentChangeResponse {
+	// this method is only offered for compatibility with future expansion;
+	// right now, all fields are copied by-value automatically
+	return r
+}
+
 // ProjectCommitmentChangeset appears in type CommitmentChangeRequest.
 // It contains all commitments that are part of a single atomic changeset that belong to a specific project in a specific AZ.
 type ProjectCommitmentChangeset struct {
@@ -58,6 +73,13 @@ type ProjectCommitmentChangeset struct {
 	// Changesets may span over multiple resources when converting commitments for one resource into commitments for another resource.
 	// In this case, the changeset will show the original commitment being deleted in one resource, and a new commitment being created in another.
 	ByResource map[ResourceName]ResourceCommitmentChangeset `json:"byResource"`
+}
+
+// Clone returns a deep copy of the given ProjectCommitmentChangeset.
+func (c ProjectCommitmentChangeset) Clone() ProjectCommitmentChangeset {
+	cloned := c
+	cloned.ByResource = clone.MapRecursively(c.ByResource)
+	return cloned
 }
 
 // ResourceCommitmentChangeset appears in type CommitmentChangeRequest.
@@ -79,6 +101,13 @@ type ResourceCommitmentChangeset struct {
 	// A commitment changeset may contain multiple commitments for a single resource within the same project.
 	// For example, when a commitment is split into two parts, the changeset will show the original commitment being deleted and two new commitments being created.
 	Commitments []Commitment `json:"commitments"`
+}
+
+// Clone returns a deep copy of the given ResourceCommitmentChangeset.
+func (c ResourceCommitmentChangeset) Clone() ResourceCommitmentChangeset {
+	cloned := c
+	cloned.Commitments = clone.SliceRecursively(c.Commitments)
+	return cloned
 }
 
 // Commitment appears in type CommitmentChangeRequest.
@@ -112,6 +141,13 @@ type Commitment struct {
 	// OldExpiresAt is set when the expiration date of an existing commitment is changed. Depending on its status
 	// RequiresConfirmation() will evaulate to different results.
 	OldExpiresAt Option[time.Time] `json:"oldExpiresAt,omitzero"`
+}
+
+// Clone returns a deep copy of the given Commitment.
+func (c Commitment) Clone() Commitment {
+	// this method is only offered for compatibility with future expansion;
+	// right now, all fields are copied by-value automatically
+	return c
 }
 
 // CommitmentStatus is an enum containing the various lifecycle states of type Commitment.

--- a/liquid/commitment.go
+++ b/liquid/commitment.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	. "github.com/majewsky/gg/option"
+
 	"github.com/sapcc/go-api-declarations/internal/clone"
 )
 

--- a/liquid/commitment_test.go
+++ b/liquid/commitment_test.go
@@ -12,6 +12,60 @@ import (
 	th "github.com/sapcc/go-api-declarations/internal/testhelper"
 )
 
+func TestCloneCommitmentChangeRequest(t *testing.T) {
+	// this dummy request sets all possible fields in order to test cloning of all levels
+	request := CommitmentChangeRequest{
+		AZ:          "az-one",
+		DryRun:      true,
+		InfoVersion: 42,
+		ByProject: map[ProjectUUID]ProjectCommitmentChangeset{
+			"uuid-for-dresden": {
+				ProjectMetadata: Some(ProjectMetadata{
+					UUID: "uuid-for-dresden",
+					Name: "dresden",
+					Domain: DomainMetadata{
+						UUID: "uuid-for-germany",
+						Name: "germany",
+					},
+				}),
+				ByResource: map[ResourceName]ResourceCommitmentChangeset{
+					"things": {
+						TotalConfirmedBefore:  10,
+						TotalConfirmedAfter:   8,
+						TotalGuaranteedBefore: 5,
+						TotalGuaranteedAfter:  5,
+						Commitments: []Commitment{{
+							UUID:         "uuid-for-commitment",
+							OldStatus:    Some(CommitmentStatusConfirmed),
+							NewStatus:    Some(CommitmentStatusExpired),
+							Amount:       2,
+							ConfirmBy:    Some(time.Now().Add(-1 * time.Hour)),
+							ExpiresAt:    time.Now(),
+							OldExpiresAt: Some(time.Now().Add(5 * time.Minute)),
+						}},
+					},
+				},
+			},
+		},
+	}
+
+	clonedRequest := request.Clone()
+	th.CheckDeepEquals(t, request, clonedRequest)
+	th.CheckFullySeparate(t, request, clonedRequest)
+}
+
+func TestCloneCommitmentChangeResponse(t *testing.T) {
+	// this dummy response sets all possible fields in order to test cloning of all levels
+	response := CommitmentChangeResponse{
+		RejectionReason: "this does not look right",
+		RetryAt:         Some(time.Now().Add(10 * time.Second)),
+	}
+
+	clonedResponse := response.Clone()
+	th.CheckDeepEquals(t, response, clonedResponse)
+	th.CheckFullySeparate(t, response, clonedResponse)
+}
+
 const (
 	dummyUUID1 = "30c343c8-7540-451a-bff5-fed9c35f8a43"
 	dummyUUID2 = "c0191273-2126-4cb9-a3cd-8288300af14e"

--- a/liquid/info.go
+++ b/liquid/info.go
@@ -3,7 +3,12 @@
 
 package liquid
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"slices"
+
+	"github.com/sapcc/go-api-declarations/internal/clone"
+)
 
 // ServiceInfo is the response payload format for GET /v1/info.
 type ServiceInfo struct {
@@ -42,6 +47,16 @@ type ServiceInfo struct {
 	CommitmentHandlingNeedsProjectMetadata bool `json:"commitmentHandlingNeedsProjectMetadata,omitempty"`
 }
 
+// Clone returns a deep copy of the given ServiceInfo.
+func (i ServiceInfo) Clone() ServiceInfo {
+	cloned := i
+	cloned.Resources = clone.MapRecursively(i.Resources)
+	cloned.Rates = clone.MapRecursively(i.Rates)
+	cloned.CapacityMetricFamilies = clone.MapRecursively(i.CapacityMetricFamilies)
+	cloned.UsageMetricFamilies = clone.MapRecursively(i.UsageMetricFamilies)
+	return cloned
+}
+
 // ResourceInfo describes a resource that a liquid's service provides.
 // This type appears in type ServiceInfo.
 type ResourceInfo struct {
@@ -75,6 +90,13 @@ type ResourceInfo struct {
 	// This must be shaped like a map[string]any, but is typed as a raw JSON message.
 	// Limes does not touch these attributes and will just pass them on into its users without deserializing it at all.
 	Attributes json.RawMessage `json:"attributes,omitempty"`
+}
+
+// Clone returns a deep copy of the given ResourceInfo.
+func (i ResourceInfo) Clone() ResourceInfo {
+	cloned := i
+	cloned.Attributes = slices.Clone(i.Attributes)
+	return cloned
 }
 
 // Topology describes how capacity and usage reported by a certain resource is structured.
@@ -146,6 +168,13 @@ type RateInfo struct {
 	// This must currently be true because there is no other reason for a rate to exist.
 	// This requirement may be relaxed in the future, if LIQUID starts modelling rate limits and there are rates that have limits, but no usage tracking.
 	HasUsage bool `json:"hasUsage"`
+}
+
+// Clone returns a deep copy of the given RateInfo.
+func (i RateInfo) Clone() RateInfo {
+	// this method is only offered for compatibility with future expansion;
+	// right now, all fields are copied by-value automatically
+	return i
 }
 
 // ProjectMetadata includes metadata about a project from Keystone.

--- a/liquid/info_test.go
+++ b/liquid/info_test.go
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package liquid
+
+import (
+	"encoding/json"
+	"testing"
+
+	th "github.com/sapcc/go-api-declarations/internal/testhelper"
+)
+
+func TestCloneServiceInfo(t *testing.T) {
+	// this dummy info sets all possible fields in order to test cloning of all levels
+	info := ServiceInfo{
+		Version: 42,
+		Resources: map[ResourceName]ResourceInfo{
+			"capacity": {
+				Unit:                UnitBytes,
+				Topology:            AZAwareTopology,
+				HasCapacity:         true,
+				NeedsResourceDemand: true,
+				HasQuota:            true,
+				HandlesCommitments:  true,
+				Attributes:          json.RawMessage(`{"foo":"bar"}`),
+			},
+		},
+		Rates: map[RateName]RateInfo{
+			"thing_creations": {
+				Unit:     UnitNone,
+				Topology: FlatTopology,
+				HasUsage: true,
+			},
+		},
+		CapacityMetricFamilies: map[MetricName]MetricFamilyInfo{
+			"foo_count": {
+				Type:      MetricTypeCounter,
+				Help:      "Counts foo things.",
+				LabelKeys: []string{"flux_polarization_setting"},
+			},
+		},
+		UsageMetricFamilies: map[MetricName]MetricFamilyInfo{
+			"bar_count": {
+				Type:      MetricTypeCounter,
+				Help:      "Counts bar things.",
+				LabelKeys: []string{"phase_shift"},
+			},
+		},
+		UsageReportNeedsProjectMetadata:        true,
+		QuotaUpdateNeedsProjectMetadata:        true,
+		CommitmentHandlingNeedsProjectMetadata: true,
+	}
+
+	clonedInfo := info.Clone()
+	th.CheckDeepEquals(t, info, clonedInfo)
+	th.CheckFullySeparate(t, info, clonedInfo)
+}

--- a/liquid/metrics.go
+++ b/liquid/metrics.go
@@ -3,6 +3,8 @@
 
 package liquid
 
+import "slices"
+
 // MetricName is the name of a metric family.
 // For more information, please refer to the "Metrics" section of the package documentation.
 type MetricName string
@@ -38,6 +40,13 @@ type MetricFamilyInfo struct {
 	LabelKeys []string `json:"labelKeys"`
 }
 
+// Clone returns a deep copy of the given MetricFamilyInfo.
+func (i MetricFamilyInfo) Clone() MetricFamilyInfo {
+	cloned := i
+	cloned.LabelKeys = slices.Clone(i.LabelKeys)
+	return cloned
+}
+
 // Metric is a metric.
 // This type appears in type ServiceCapacityReport.
 // For more information, please refer to the "Metrics" section of the package documentation.
@@ -51,4 +60,11 @@ type Metric struct {
 	// Each label value is implied to belong to the label key with the same slice index.
 	// For example, LabelKeys = ["name","location"] and LabelValues = ["author","work"] represents the label set {name="author",location="work"}.
 	LabelValues []string `json:"l"`
+}
+
+// Clone returns a deep copy of the given Metric.
+func (m Metric) Clone() Metric {
+	cloned := m
+	cloned.LabelValues = slices.Clone(m.LabelValues)
+	return cloned
 }

--- a/liquid/quota.go
+++ b/liquid/quota.go
@@ -5,6 +5,7 @@ package liquid
 
 import (
 	. "github.com/majewsky/gg/option"
+
 	"github.com/sapcc/go-api-declarations/internal/clone"
 )
 

--- a/liquid/quota.go
+++ b/liquid/quota.go
@@ -3,7 +3,10 @@
 
 package liquid
 
-import . "github.com/majewsky/gg/option"
+import (
+	. "github.com/majewsky/gg/option"
+	"github.com/sapcc/go-api-declarations/internal/clone"
+)
 
 // ServiceQuotaRequest is the request payload format for PUT /v1/projects/:uuid/quota.
 type ServiceQuotaRequest struct {
@@ -12,6 +15,13 @@ type ServiceQuotaRequest struct {
 	// Metadata about the project from Keystone.
 	// Only included if the ServiceInfo declared a need for it.
 	ProjectMetadata Option[ProjectMetadata] `json:"projectMetadata,omitzero"`
+}
+
+// Clone returns a deep copy of the given ServiceQuotaRequest.
+func (i ServiceQuotaRequest) Clone() ServiceQuotaRequest {
+	cloned := i
+	cloned.Resources = clone.MapRecursively(i.Resources)
+	return cloned
 }
 
 // ResourceQuotaRequest contains new quotas for a single resource.
@@ -25,6 +35,13 @@ type ResourceQuotaRequest struct {
 	PerAZ map[AvailabilityZone]AZResourceQuotaRequest `json:"perAZ,omitempty"`
 }
 
+// Clone returns a deep copy of the given ResourceQuotaRequest.
+func (i ResourceQuotaRequest) Clone() ResourceQuotaRequest {
+	cloned := i
+	cloned.PerAZ = clone.MapRecursively(i.PerAZ)
+	return cloned
+}
+
 // AZResourceQuotaRequest contains the new quota value for a single resource and AZ.
 // It appears in type ResourceQuotaRequest.
 type AZResourceQuotaRequest struct {
@@ -33,4 +50,11 @@ type AZResourceQuotaRequest struct {
 	// This struct looks superfluous (why not just have a bare uint64?), but in
 	// the event that more data needs to be added in the future, having this
 	// struct allows for that to be a backwards-compatible change.
+}
+
+// Clone returns a deep copy of the given AZResourceQuotaRequest.
+func (i AZResourceQuotaRequest) Clone() AZResourceQuotaRequest {
+	// this method is only offered for compatibility with future expansion;
+	// right now, all fields are copied by-value automatically
+	return i
 }

--- a/liquid/quota_test.go
+++ b/liquid/quota_test.go
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package liquid
+
+import (
+	"testing"
+
+	. "github.com/majewsky/gg/option"
+
+	th "github.com/sapcc/go-api-declarations/internal/testhelper"
+)
+
+func TestCloneServiceQuotaRequest(t *testing.T) {
+	// this dummy request sets all possible fields in order to test cloning of all levels
+	request := ServiceQuotaRequest{
+		Resources: map[ResourceName]ResourceQuotaRequest{
+			"capacity": {
+				PerAZ: map[AvailabilityZone]AZResourceQuotaRequest{
+					"az-one": {
+						Quota: 100,
+					},
+				},
+			},
+		},
+		ProjectMetadata: Some(ProjectMetadata{
+			UUID: "uuid-for-dresden",
+			Name: "dresden",
+			Domain: DomainMetadata{
+				UUID: "uuid-for-germany",
+				Name: "germany",
+			},
+		}),
+	}
+
+	clonedRequest := request.Clone()
+	th.CheckDeepEquals(t, request, clonedRequest)
+	th.CheckFullySeparate(t, request, clonedRequest)
+}

--- a/liquid/report_capacity.go
+++ b/liquid/report_capacity.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 
 	. "github.com/majewsky/gg/option"
+
 	"github.com/sapcc/go-api-declarations/internal/clone"
 )
 

--- a/liquid/report_capacity.go
+++ b/liquid/report_capacity.go
@@ -3,7 +3,12 @@
 
 package liquid
 
-import . "github.com/majewsky/gg/option"
+import (
+	"slices"
+
+	. "github.com/majewsky/gg/option"
+	"github.com/sapcc/go-api-declarations/internal/clone"
+)
 
 // ServiceCapacityRequest is the request payload format for POST /v1/report-capacity.
 type ServiceCapacityRequest struct {
@@ -18,6 +23,14 @@ type ServiceCapacityRequest struct {
 	DemandByResource map[ResourceName]ResourceDemand `json:"demandByResource"`
 }
 
+// Clone returns a deep copy of the given ServiceCapacityRequest.
+func (r ServiceCapacityRequest) Clone() ServiceCapacityRequest {
+	cloned := r
+	cloned.AllAZs = slices.Clone(r.AllAZs)
+	cloned.DemandByResource = clone.MapRecursively(r.DemandByResource)
+	return cloned
+}
+
 // ResourceDemand contains demand statistics for a resource.
 // It appears in type ServiceCapacityRequest.
 //
@@ -30,6 +43,13 @@ type ResourceDemand struct {
 	// The actual demand values are AZ-aware.
 	// The keys that can be expected in this map depend on the chosen Topology.
 	PerAZ map[AvailabilityZone]ResourceDemandInAZ `json:"perAZ"`
+}
+
+// Clone returns a deep copy of the given ResourceDemand.
+func (d ResourceDemand) Clone() ResourceDemand {
+	cloned := d
+	cloned.PerAZ = clone.MapRecursively(d.PerAZ)
+	return cloned
 }
 
 // ResourceDemandInAZ contains demand statistics for a resource in a single AZ.
@@ -48,6 +68,13 @@ type ResourceDemandInAZ struct {
 	PendingCommitments uint64 `json:"pendingCommitments"`
 }
 
+// Clone returns a deep copy of the given ResourceDemandInAZ.
+func (d ResourceDemandInAZ) Clone() ResourceDemandInAZ {
+	// this method is only offered for compatibility with future expansion;
+	// right now, all fields are copied by-value automatically
+	return d
+}
+
 // ServiceCapacityReport is the response payload format for POST /v1/report-capacity.
 type ServiceCapacityReport struct {
 	// The same version number that is reported in the Version field of a GET /v1/info response.
@@ -61,12 +88,27 @@ type ServiceCapacityReport struct {
 	Metrics map[MetricName][]Metric `json:"metrics,omitempty"`
 }
 
+// Clone returns a deep copy of the given ServiceCapacityReport.
+func (r ServiceCapacityReport) Clone() ServiceCapacityReport {
+	cloned := r
+	cloned.Resources = clone.MapOfPointersRecursively(r.Resources)
+	cloned.Metrics = clone.MapOfSlicesRecursively(r.Metrics)
+	return cloned
+}
+
 // ResourceCapacityReport contains capacity data for a resource.
 // It appears in type ServiceCapacityReport.
 type ResourceCapacityReport struct {
 	// The keys that are allowed in this map depend on the chosen Topology.
 	// See documentation on Topology enum variants for details.
 	PerAZ map[AvailabilityZone]*AZResourceCapacityReport `json:"perAZ"`
+}
+
+// Clone returns a deep copy of the given ResourceCapacityReport.
+func (r ResourceCapacityReport) Clone() ResourceCapacityReport {
+	cloned := r
+	cloned.PerAZ = clone.MapOfPointersRecursively(r.PerAZ)
+	return cloned
 }
 
 // AZResourceCapacityReport contains capacity data for a resource in a single AZ.
@@ -98,4 +140,11 @@ type AZResourceCapacityReport struct {
 
 	// Only filled if the resource is able to report subcapacities in a useful way.
 	Subcapacities []Subcapacity `json:"subcapacities,omitempty"`
+}
+
+// Clone returns a deep copy of the given AZResourceCapacityReport.
+func (r AZResourceCapacityReport) Clone() AZResourceCapacityReport {
+	cloned := r
+	cloned.Subcapacities = clone.SliceRecursively(r.Subcapacities)
+	return cloned
 }

--- a/liquid/report_capacity_test.go
+++ b/liquid/report_capacity_test.go
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package liquid
+
+import (
+	"encoding/json"
+	"testing"
+
+	. "github.com/majewsky/gg/option"
+
+	th "github.com/sapcc/go-api-declarations/internal/testhelper"
+)
+
+func TestCloneServiceCapacityRequest(t *testing.T) {
+	// this dummy request sets all possible fields in order to test cloning of all levels
+	request := ServiceCapacityRequest{
+		AllAZs: []AvailabilityZone{"az-one"},
+		DemandByResource: map[ResourceName]ResourceDemand{
+			"capacity": {
+				OvercommitFactor: 1.1,
+				PerAZ: map[AvailabilityZone]ResourceDemandInAZ{
+					"az-one": {
+						Usage:              100,
+						UnusedCommitments:  20,
+						PendingCommitments: 10,
+					},
+				},
+			},
+		},
+	}
+
+	clonedRequest := request.Clone()
+	th.CheckDeepEquals(t, request, clonedRequest)
+	th.CheckFullySeparate(t, request, clonedRequest)
+}
+
+func TestCloneServiceCapacityReport(t *testing.T) {
+	// this dummy report sets all possible fields in order to test cloning of all levels
+	report := ServiceCapacityReport{
+		InfoVersion: 42,
+		Resources: map[ResourceName]*ResourceCapacityReport{
+			"capacity": {
+				PerAZ: map[AvailabilityZone]*AZResourceCapacityReport{
+					"az-one": {
+						Capacity: 1000,
+						Usage:    Some[uint64](500),
+						Subcapacities: []Subcapacity{{
+							ID:         "id-1",
+							Name:       "first",
+							Capacity:   1000,
+							Usage:      Some[uint64](500),
+							Attributes: json.RawMessage(`{"foo":"bar"}`),
+						}},
+					},
+				},
+			},
+		},
+		Metrics: map[MetricName][]Metric{
+			"foo_count": {{
+				Value:       23,
+				LabelValues: []string{"qux"},
+			}},
+		},
+	}
+
+	clonedReport := report.Clone()
+	th.CheckDeepEquals(t, report, clonedReport)
+	th.CheckFullySeparate(t, report, clonedReport)
+}

--- a/liquid/report_usage.go
+++ b/liquid/report_usage.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 
 	. "github.com/majewsky/gg/option"
+
 	"github.com/sapcc/go-api-declarations/internal/clone"
 )
 

--- a/liquid/report_usage.go
+++ b/liquid/report_usage.go
@@ -6,8 +6,10 @@ package liquid
 import (
 	"encoding/json"
 	"math/big"
+	"slices"
 
 	. "github.com/majewsky/gg/option"
+	"github.com/sapcc/go-api-declarations/internal/clone"
 )
 
 // ServiceUsageRequest is the request payload format for POST /v1/projects/:uuid/report-usage.
@@ -26,6 +28,14 @@ type ServiceUsageRequest struct {
 	// The serialized state from the previous ServiceUsageReport received by Limes for this project, if any.
 	// Refer to the same field on type ServiceUsageReport for details.
 	SerializedState json.RawMessage `json:"serializedState,omitempty"`
+}
+
+// Clone returns a deep copy of the given ServiceUsageRequest.
+func (r ServiceUsageRequest) Clone() ServiceUsageRequest {
+	cloned := r
+	cloned.AllAZs = slices.Clone(r.AllAZs)
+	cloned.SerializedState = slices.Clone(r.SerializedState)
+	return cloned
 }
 
 // ServiceUsageReport is the response payload format for POST /v1/projects/:uuid/report-usage.
@@ -54,6 +64,16 @@ type ServiceUsageReport struct {
 	SerializedState json.RawMessage `json:"serializedState,omitempty"`
 }
 
+// Clone returns a deep copy of the given ServiceUsageReport.
+func (r ServiceUsageReport) Clone() ServiceUsageReport {
+	cloned := r
+	cloned.Resources = clone.MapOfPointersRecursively(r.Resources)
+	cloned.Rates = clone.MapOfPointersRecursively(r.Rates)
+	cloned.Metrics = clone.MapOfSlicesRecursively(r.Metrics)
+	cloned.SerializedState = slices.Clone(r.SerializedState)
+	return cloned
+}
+
 // ResourceUsageReport contains usage data for a resource in a single project.
 // It appears in type ServiceUsageReport.
 type ResourceUsageReport struct {
@@ -72,6 +92,13 @@ type ResourceUsageReport struct {
 	//
 	// Tip: When filling this by starting from a non-AZ-aware usage number that is later broken down with AZ-aware data, use func PrepareForBreakdownInto.
 	PerAZ map[AvailabilityZone]*AZResourceUsageReport `json:"perAZ"`
+}
+
+// Clone returns a deep copy of the given ResourceUsageReport.
+func (r ResourceUsageReport) Clone() ResourceUsageReport {
+	cloned := r
+	cloned.PerAZ = clone.MapOfPointersRecursively(r.PerAZ)
+	return cloned
 }
 
 // AZResourceUsageReport contains usage data for a resource in a single project and AZ.
@@ -94,6 +121,13 @@ type AZResourceUsageReport struct {
 
 	// Only filled if the resource is able to report subresources for this usage in a useful way.
 	Subresources []Subresource `json:"subresources,omitempty"`
+}
+
+// Clone returns a deep copy of the given AZResourceUsageReport.
+func (r AZResourceUsageReport) Clone() AZResourceUsageReport {
+	cloned := r
+	cloned.Subresources = clone.SliceRecursively(r.Subresources)
+	return cloned
 }
 
 // PrepareForBreakdownInto is a convenience constructor for the PerAZ field of ResourceUsageReport.
@@ -141,6 +175,13 @@ type RateUsageReport struct {
 	PerAZ map[AvailabilityZone]*AZRateUsageReport `json:"perAZ"`
 }
 
+// Clone returns a deep copy of the given RateUsageReport.
+func (r RateUsageReport) Clone() RateUsageReport {
+	cloned := r
+	cloned.PerAZ = clone.MapOfPointersRecursively(r.PerAZ)
+	return cloned
+}
+
 // AZRateUsageReport contains usage data for a rate in a single project and AZ.
 // It appears in type RateUsageReport.
 type AZRateUsageReport struct {
@@ -153,4 +194,13 @@ type AZRateUsageReport struct {
 	//
 	// This field is modeled as a bigint because network rates like "bytes transferred" may easily exceed the range of uint64 over time.
 	Usage Option[*big.Int] `json:"usage,omitzero"`
+}
+
+// Clone returns a deep copy of the given AZRateUsageReport.
+func (r AZRateUsageReport) Clone() AZRateUsageReport {
+	cloned := r
+	if usage, ok := r.Usage.Unpack(); ok {
+		cloned.Usage = Some(big.NewInt(0).Set(usage))
+	}
+	return cloned
 }

--- a/liquid/report_usage_test.go
+++ b/liquid/report_usage_test.go
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package liquid
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	. "github.com/majewsky/gg/option"
+
+	th "github.com/sapcc/go-api-declarations/internal/testhelper"
+)
+
+func TestCloneServiceUsageRequest(t *testing.T) {
+	// this dummy request sets all possible fields in order to test cloning of all levels
+	request := ServiceUsageRequest{
+		AllAZs: []AvailabilityZone{"az-one"},
+		ProjectMetadata: Some(ProjectMetadata{
+			UUID: "uuid-for-dresden",
+			Name: "dresden",
+			Domain: DomainMetadata{
+				UUID: "uuid-for-germany",
+				Name: "germany",
+			},
+		}),
+		SerializedState: json.RawMessage(`{"state":"d41d8cd98f00b204e9800998ecf8427e"}`),
+	}
+
+	clonedRequest := request.Clone()
+	th.CheckDeepEquals(t, request, clonedRequest)
+	th.CheckFullySeparate(t, request, clonedRequest)
+}
+
+func TestCloneServiceUsageReport(t *testing.T) {
+	// this dummy report sets all possible fields in order to test cloning of all levels
+	report := ServiceUsageReport{
+		InfoVersion: 42,
+		Resources: map[ResourceName]*ResourceUsageReport{
+			"capacity": {
+				Forbidden: true,
+				Quota:     Some[int64](10),
+				PerAZ: map[AvailabilityZone]*AZResourceUsageReport{
+					"az-one": {
+						Usage:         5,
+						PhysicalUsage: Some[uint64](2),
+						Quota:         Some[int64](10),
+						Subresources: []Subresource{{
+							ID:         "id-1",
+							Name:       "first",
+							Usage:      Some[uint64](5),
+							Attributes: json.RawMessage(`{"foo":"bar"}`),
+						}},
+					},
+				},
+			},
+		},
+		Rates: map[RateName]*RateUsageReport{
+			"thing_creations": {
+				PerAZ: map[AvailabilityZone]*AZRateUsageReport{
+					AvailabilityZoneAny: {
+						Usage: Some(big.NewInt(23)),
+					},
+				},
+			},
+		},
+		Metrics: map[MetricName][]Metric{
+			"bar_count": {{
+				Value:       23,
+				LabelValues: []string{"qux"},
+			}},
+		},
+		SerializedState: json.RawMessage(`{"state":"d41d8cd98f00b204e9800998ecf8427e"}`),
+	}
+
+	clonedReport := report.Clone()
+	th.CheckDeepEquals(t, report, clonedReport)
+	th.CheckFullySeparate(t, report, clonedReport)
+}

--- a/liquid/subdivisions.go
+++ b/liquid/subdivisions.go
@@ -5,6 +5,7 @@ package liquid
 
 import (
 	"encoding/json"
+	"slices"
 
 	. "github.com/majewsky/gg/option"
 )
@@ -39,6 +40,13 @@ type Subcapacity struct {
 	// This must be shaped like a map[string]any, but is typed as a raw JSON message.
 	// Limes does not touch these attributes and will just pass them on into its users without deserializing it at all.
 	Attributes json.RawMessage `json:"attributes,omitempty"`
+}
+
+// Clone returns a deep copy of the given Subcapacity.
+func (s Subcapacity) Clone() Subcapacity {
+	cloned := s
+	cloned.Attributes = slices.Clone(s.Attributes)
+	return cloned
 }
 
 // SubcapacityBuilder is a helper type for building Subcapacity values.
@@ -88,6 +96,13 @@ type Subresource struct {
 	// This must be shaped like a map[string]any, but is typed as a raw JSON message.
 	// Limes does not touch these attributes and will just pass them on into its users without deserializing it at all.
 	Attributes json.RawMessage `json:"attributes,omitempty"`
+}
+
+// Clone returns a deep copy of the given Subresource.
+func (s Subresource) Clone() Subresource {
+	cloned := s
+	cloned.Attributes = slices.Clone(s.Attributes)
+	return cloned
 }
 
 // SubresourceBuilder is a helper type for building Subresource values.


### PR DESCRIPTION
Similar capabilities already exist in Limes privately, for the purposes of implementing test doubles. Moving this here will ensure that the Clone() implementations are updated together with the types they are based on, thus avoiding accidental implementation drift.