### PR TITLE
liquid: allow (and require) declaring limit-only rates

### DIFF
--- a/liquid/info.go
+++ b/liquid/info.go
@@ -237,8 +237,6 @@ type RateInfo struct {
 	Topology Topology `json:"topology"`
 
 	// Whether the liquid reports usage for this rate on the project level.
-	// This must currently be true because there is no other reason for a rate to exist.
-	// This requirement may be relaxed in the future, if LIQUID starts modelling rate limits and there are rates that have limits, but no usage tracking.
 	HasUsage bool `json:"hasUsage"`
 }
 

--- a/liquid/report_usage.go
+++ b/liquid/report_usage.go
@@ -48,7 +48,7 @@ type ServiceUsageReport struct {
 	// Must contain an entry for each resource that was declared in type [ServiceInfo].
 	Resources map[ResourceName]*ResourceUsageReport `json:"resources,omitempty"`
 
-	// Must contain an entry for each rate that was declared in type [ServiceInfo].
+	// Must contain an entry for each rate that was declared in type [ServiceInfo] with "HasUsage = true".
 	Rates map[RateName]*RateUsageReport `json:"rates,omitempty"`
 
 	// Must contain an entry for each metric family that was declared for usage metrics in type [ServiceInfo].

--- a/liquid/validation.go
+++ b/liquid/validation.go
@@ -25,7 +25,6 @@ func isValidIdentifier[S ~string](s S) bool {
 //   - Each resource and rate must have a valid name, according to ResourceName.IsValid() and RateName.IsValid().
 //   - Each resource is declared with a valid topology.
 //   - Each rate is declared with a valid topology.
-//   - Each rate is declared with HasUsage = true.
 //
 // Additional validations may be added in the future.
 func ValidateServiceInfo(srv ServiceInfo) error {
@@ -67,9 +66,6 @@ func validateServiceInfoImpl(srv ServiceInfo) (errs errorset.ErrorSet) {
 		}
 		if !rate.Topology.IsValid() {
 			errs.Addf(".Rates[%q] has invalid topology %q", rateName, srv.Rates[rateName].Topology)
-		}
-		if !rate.HasUsage {
-			errs.Addf(".Rates[%q] declared with HasUsage = false, but must be true", rateName)
 		}
 		category, hasCategory := rate.Category.Unpack()
 		if hasCategory {
@@ -212,9 +208,8 @@ func validateUsageReportImpl(report ServiceUsageReport, req ServiceUsageRequest,
 		errs.Add(validateQuotaAgainstTopology(res, resInfo.HasQuota, resInfo.Topology, resName, req.AllAZs))
 	}
 	// validate rate reports
-	for rateName := range info.Rates {
-		// HasUsage = true is implicit and gets verified in the ServiceInfo
-		if !hasKey(report.Rates, rateName) {
+	for rateName, rateInfo := range info.Rates {
+		if rateInfo.HasUsage && !hasKey(report.Rates, rateName) {
 			errs.Addf("missing value for .Rates[%q]", rateName)
 		}
 	}
@@ -222,6 +217,10 @@ func validateUsageReportImpl(report ServiceUsageReport, req ServiceUsageRequest,
 		rateInfo, exists := info.Rates[rateName]
 		if !exists {
 			errs.Addf("unexpected value for .Rates[%q] (rate was not declared)", rateName)
+			continue
+		}
+		if !rateInfo.HasUsage {
+			errs.Addf("unexpected value for .Rates[%q] (rate was declared with HasUsage = false)", rateName)
 			continue
 		}
 		errs.Add(validatePerAZAgainstTopology(rate.PerAZ, rateInfo.Topology, ".Rates", rateName, req.AllAZs))

--- a/liquid/validation_test.go
+++ b/liquid/validation_test.go
@@ -84,6 +84,11 @@ var serviceInfo = ServiceInfo{
 			HasUsage: true,
 			Topology: AZAwareTopology,
 		},
+		"object_creations": {
+			Unit:     UnitNone,
+			HasUsage: false,
+			Topology: AZAwareTopology,
+		},
 	},
 	CapacityMetricFamilies: map[MetricName]MetricFamilyInfo{
 		"capacityMetric1": {
@@ -126,7 +131,6 @@ func TestValidateServiceInfo(t *testing.T) {
 		Rates: map[RateName]RateInfo{
 			"corge":      {Category: Some(CategoryName("empty")), HasUsage: true}, // Topology is missing
 			"grault":     {Category: Some(CategoryName("valid")), HasUsage: true, Topology: "InvalidTopology"},
-			"garply":     {Category: Some(CategoryName("valid")), HasUsage: false, Topology: AZSeparatedTopology}, // HasUsage = false is not allowed
 			"waldo":      {Category: Some(CategoryName("valid")), HasUsage: true, Topology: AZSeparatedTopology},
 			"foo/create": {Category: Some(CategoryName("valid")), HasUsage: true, Topology: FlatTopology},               // Invalid name
 			"bla1":       {Category: Some(CategoryName("")), HasUsage: true, Topology: FlatTopology},                    // Invalid category
@@ -139,7 +143,6 @@ func TestValidateServiceInfo(t *testing.T) {
 		`.Resources["foo+private"] has invalid name (must match /^[a-zA-Z][a-zA-Z0-9._-]*$/)`,
 		`.Rates["corge"] has invalid topology ""`,
 		`.Rates["grault"] has invalid topology "InvalidTopology"`,
-		`.Rates["garply"] declared with HasUsage = false, but must be true`,
 		`.Rates["foo/create"] has invalid name (must match /^[a-zA-Z][a-zA-Z0-9._-]*$/)`,
 		`.Resources["qux1"] has invalid category ""`,
 		`.Resources["qux2"] has category "someUnknownCategory", which is not declared in .Categories`,
@@ -317,6 +320,11 @@ func TestValidateUsageReport(t *testing.T) {
 					"az-one": {Usage: Some(big.NewInt(5))}, // Partial AZ aware reporting, az-two is missing
 				},
 			},
+			"object_creations": {
+				PerAZ: map[AvailabilityZone]*AZRateUsageReport{
+					"any": {Usage: Some(big.NewInt(10))}, // Unexpected: rate was declared as HasUsage = false
+				},
+			},
 			"unknown": {
 				PerAZ: map[AvailabilityZone]*AZRateUsageReport{
 					"any": {Usage: Some(big.NewInt(5))}, // Report for rate which is not in ServiceInfo
@@ -344,6 +352,7 @@ func TestValidateUsageReport(t *testing.T) {
 		`.Rates["grault"].PerAZ has entries for []liquid.AvailabilityZone{"az-one", "az-two"}, which is invalid for topology "flat" (expected entries for []liquid.AvailabilityZone{"any"})`,
 		`.Rates["garply"].PerAZ has entries for []liquid.AvailabilityZone{"any"}, which is invalid for topology "az-aware" (expected entries for []liquid.AvailabilityZone{"az-one", "az-two"})`,
 		`.Rates["waldo"].PerAZ has entries for []liquid.AvailabilityZone{"az-one"}, which is invalid for topology "az-aware" (expected entries for []liquid.AvailabilityZone{"az-one", "az-two"})`,
+		`unexpected value for .Rates["object_creations"] (rate was declared with HasUsage = false)`,
 		`unexpected value for .Rates["unknown"] (rate was not declared)`,
 		`missing value for .Metrics["usageMetric1"] (declared in .UsageMetricFamilies)`,
 		`unexpected value for .Metrics["unknownMetric"] (not declared in .UsageMetricFamilies)`,


### PR DESCRIPTION
The distinction between "rates that are declared in LIQUID because they report usage" and "rates that are only declared in the Limes config because they only have limits" is causing confusion in the Limes codebase. Since it might in the future be required to declare the second type of rate in LIQUID anyway (if LIQUID becomes a method for delivering rate limit values into backend services), we might as well introduce the declaration requirement right now to simplify our lives as Limes devs.