### PR TITLE
add query parsing and serialization

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/sapcc/go-api-declarations
 
-go 1.24
+go 1.26
 
 require go.xyrillian.de/gg v1.7.0

--- a/internal/testhelper/clone.go
+++ b/internal/testhelper/clone.go
@@ -83,8 +83,8 @@ func walkByReference(v reflect.Value, action func(reflect.Value)) {
 			return
 		}
 
-		for idx := range v.NumField() {
-			walkByReference(v.Field(idx), action)
+		for _, field := range v.Fields() {
+			walkByReference(field, action)
 		}
 	}
 }

--- a/limes/rates/report_project_test.go
+++ b/limes/rates/report_project_test.go
@@ -81,17 +81,17 @@ var projectMockServicesRateLimit = &ProjectServiceReports{
 			"services/swift/account/container/object:create": {
 				RateInfo: RateInfo{Name: "services/swift/account/container/object:create"},
 				Limit:    1000,
-				Window:   p2window(1 * WindowSeconds),
+				Window:   new(1 * WindowSeconds),
 			},
 			"services/swift/account/container/object:delete": {
 				RateInfo: RateInfo{Name: "services/swift/account/container/object:delete"},
 				Limit:    1000,
-				Window:   p2window(1 * WindowSeconds),
+				Window:   new(1 * WindowSeconds),
 			},
 			"services/swift/account:create": {
 				RateInfo: RateInfo{Name: "services/swift/account:create"},
 				Limit:    10,
-				Window:   p2window(1 * WindowMinutes),
+				Window:   new(1 * WindowMinutes),
 			},
 		},
 		ScrapedAt: p2time(22),
@@ -108,23 +108,23 @@ var projectMockServicesRateLimitDeviatingFromDefaults = &ProjectServiceReports{
 			"services/swift/account/container/object:create": {
 				RateInfo:      RateInfo{Name: "services/swift/account/container/object:create"},
 				Limit:         1000,
-				Window:        p2window(1 * WindowSeconds),
+				Window:        new(1 * WindowSeconds),
 				DefaultLimit:  500,
-				DefaultWindow: p2window(1 * WindowSeconds),
+				DefaultWindow: new(1 * WindowSeconds),
 			},
 			"services/swift/account/container/object:delete": {
 				RateInfo:      RateInfo{Name: "services/swift/account/container/object:delete"},
 				Limit:         1000,
-				Window:        p2window(1 * WindowSeconds),
+				Window:        new(1 * WindowSeconds),
 				DefaultLimit:  500,
-				DefaultWindow: p2window(1 * WindowSeconds),
+				DefaultWindow: new(1 * WindowSeconds),
 			},
 			"services/swift/account:create": {
 				RateInfo:      RateInfo{Name: "services/swift/account:create"},
 				Limit:         10,
-				Window:        p2window(1 * WindowMinutes),
+				Window:        new(1 * WindowMinutes),
 				DefaultLimit:  5,
-				DefaultWindow: p2window(1 * WindowMinutes),
+				DefaultWindow: new(1 * WindowMinutes),
 			},
 		},
 		ScrapedAt: p2time(22),
@@ -156,8 +156,4 @@ func TestProjectServicesRateLimitDeviatingFromDefaultsUnmarshall(t *testing.T) {
 func p2time(timestamp int64) *limes.UnixEncodedTime {
 	t := limes.UnixEncodedTime{Time: time.Unix(timestamp, 0).UTC()}
 	return &t
-}
-
-func p2window(val Window) *Window {
-	return &val
 }

--- a/limes/resources/report_cluster_test.go
+++ b/limes/resources/report_cluster_test.go
@@ -107,11 +107,11 @@ var clusterMockResources = &ClusterResourceReports{
 		PerAZ: map[limes.AvailabilityZone]*ClusterAZResourceReport{
 			"az-one": {
 				Capacity: 250,
-				Usage:    p2u64(70),
+				Usage:    new(uint64(70)),
 			},
 			"az-two": {
 				Capacity: 250,
-				Usage:    p2u64(30),
+				Usage:    new(uint64(30)),
 			},
 		},
 		CapacityPerAZ: ClusterAvailabilityZoneReports{
@@ -126,7 +126,7 @@ var clusterMockResources = &ClusterResourceReports{
 				Usage:    30,
 			},
 		},
-		DomainsQuota: p2u64(200),
+		DomainsQuota: new(uint64(200)),
 		Usage:        100,
 	},
 	"ram": &ClusterResourceReport{
@@ -135,7 +135,7 @@ var clusterMockResources = &ClusterResourceReports{
 			Unit: limes.UnitMebibytes,
 		},
 		Capacity:     &ramCap,
-		DomainsQuota: p2u64(102400),
+		DomainsQuota: new(uint64(102400)),
 		Usage:        40800,
 	},
 }
@@ -153,10 +153,6 @@ var clusterMockServices = &ClusterServiceReports{
 		MaxScrapedAt: p2time(1539024049),
 		MinScrapedAt: p2time(1539023764),
 	},
-}
-
-func p2u64(val uint64) *uint64 {
-	return &val
 }
 
 func TestClusterServicesMarshal(t *testing.T) {

--- a/limes/resources/report_domain_test.go
+++ b/limes/resources/report_domain_test.go
@@ -59,8 +59,8 @@ var domainMockResources = &DomainResourceReports{
 		ResourceInfo: ResourceInfo{
 			Name: "cores",
 		},
-		DomainQuota:   p2u64(50),
-		ProjectsQuota: p2u64(20),
+		DomainQuota:   new(uint64(50)),
+		ProjectsQuota: new(uint64(20)),
 		Usage:         10,
 	},
 	"ram": &DomainResourceReport{
@@ -68,8 +68,8 @@ var domainMockResources = &DomainResourceReports{
 			Name: "ram",
 			Unit: limes.UnitMebibytes,
 		},
-		DomainQuota:   p2u64(20480),
-		ProjectsQuota: p2u64(10240),
+		DomainQuota:   new(uint64(20480)),
+		ProjectsQuota: new(uint64(10240)),
 		Usage:         4080,
 	},
 }

--- a/limes/resources/report_project_test.go
+++ b/limes/resources/report_project_test.go
@@ -97,11 +97,11 @@ var projectMockResources = &ProjectResourceReports{
 			Unit: limes.UnitBytes,
 		},
 		PerAZ: ProjectAZResourceReports{
-			"az-one": {Quota: p2u64(6), Usage: 2, Committed: map[string]uint64{"1 year": 3}},
-			"az-two": {Quota: p2u64(4), Usage: 0},
+			"az-one": {Quota: new(uint64(6)), Usage: 2, Committed: map[string]uint64{"1 year": 3}},
+			"az-two": {Quota: new(uint64(4)), Usage: 0},
 		},
-		Quota:       p2u64(10),
-		UsableQuota: p2u64(11),
+		Quota:       new(uint64(10)),
+		UsableQuota: new(uint64(11)),
 		Usage:       2,
 	},
 	"things": &ProjectResourceReport{
@@ -111,8 +111,8 @@ var projectMockResources = &ProjectResourceReports{
 		PerAZ: ProjectAZResourceReports{
 			limes.AvailabilityZoneAny: {Usage: 2},
 		},
-		Quota:       p2u64(10),
-		UsableQuota: p2u64(10),
+		Quota:       new(uint64(10)),
+		UsableQuota: new(uint64(10)),
 		Usage:       2,
 	},
 }

--- a/liquid/option_test.go
+++ b/liquid/option_test.go
@@ -48,9 +48,8 @@ func getOptionTypesRecursively(t *testing.T, rt reflect.Type, optionTypes map[re
 			optionTypes[field.Type] = struct{}{}
 			getOptionTypesRecursively(t, field.Type, optionTypes)
 		} else {
-			for idx := range rt.NumField() {
-				f := rt.Field(idx)
-				getOptionTypesRecursively(t, f.Type, optionTypes)
+			for field := range rt.Fields() {
+				getOptionTypesRecursively(t, field.Type, optionTypes)
 			}
 		}
 	}

--- a/opts/parse.go
+++ b/opts/parse.go
@@ -11,6 +11,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	. "go.xyrillian.de/gg/option"
 )
 
 // ParseQueryString parses the query parameters of url.Values into an opt struct.
@@ -52,8 +54,8 @@ import (
 //
 //	Bar map[string]string `q:"bar"`              // ?bar=k1:v1&bar=k2:v2
 //
-// [time.Time] fields support the formats defined under [opts.TimeFormats].
-// A single "format" option must be set, to limit what the parser accepts:
+// [time.Time] fields support the formats RFC3339Nano, RFC3339, DateTime, Date, Unix
+// (seconds since epoch). A single "format" option must be set, to limit what the parser accepts:
 //
 //	Baz time.Time `q:"baz,format:RFC3339"`       // ?baz=1999-01-01T00:00:00
 //
@@ -74,7 +76,7 @@ func ParseQueryString[T any](query url.Values) (T, error) {
 	type optMeta struct {
 		structField       reflect.StructField
 		fieldValue        reflect.Value
-		timeFormat        string // "" or time-formats
+		maybeTimeFormat   Option[string]
 		requiredAndUnseen bool
 	}
 	knownOpts := make(map[string]optMeta, optsType.NumField())
@@ -91,18 +93,20 @@ func ParseQueryString[T any](query url.Values) (T, error) {
 		if qTag == "" {
 			panic(fmt.Sprintf(`expected %q to have a "q:"-tag`, field.Name))
 		}
-		optKey, timeFormat, required := parseQTag(qTag)
+		optKey, maybeTimeFormat, required := parseQTag(qTag)
 		if !fieldValue.CanSet() {
 			panic(fmt.Sprintf(`field %q is unexported and therefore cannot be set`, optKey))
 		}
-		// all known formats are currently timeFormats
-		if _, ok := TimeFormats[timeFormat]; timeFormat != "" && timeFormat != UnixFormat && !ok {
-			panic(fmt.Sprintf("unsupported time format %q; accepted: %s", timeFormat, supportedHumanReadableFormats))
+
+		// check if format is set when required
+		if typeNeedsTimeFormat(fieldValue.Type()) && maybeTimeFormat.IsNone() {
+			panic(fmt.Sprintf(`time format is missing for field %q`, field.Name))
 		}
+
 		knownOpts[optKey] = optMeta{
 			structField:       field,
 			fieldValue:        fieldValue,
-			timeFormat:        timeFormat,
+			maybeTimeFormat:   maybeTimeFormat,
 			requiredAndUnseen: required,
 		}
 	}
@@ -114,11 +118,11 @@ func ParseQueryString[T any](query url.Values) (T, error) {
 			return opts, fmt.Errorf("unknown query parameter %q", optKey)
 		}
 		// now, just set the value of the field accordingly
-		err := setField(meta.structField, meta.fieldValue, rawValues, meta.timeFormat)
+		err := setField(meta.structField, meta.fieldValue, rawValues, meta.maybeTimeFormat)
 		if err != nil {
 			return opts, fmt.Errorf("invalid value for query parameter %q: %w", optKey, err)
 		}
-		if !isZero(meta.fieldValue) && meta.requiredAndUnseen {
+		if !isOnlyEmptyStrings(rawValues) && meta.requiredAndUnseen {
 			meta.requiredAndUnseen = false
 			knownOpts[optKey] = meta
 		}
@@ -133,9 +137,19 @@ func ParseQueryString[T any](query url.Values) (T, error) {
 	return opts, nil
 }
 
+// isOnlyEmptyStrings checks if all rawValues are only emptyStrings.
+func isOnlyEmptyStrings(rawvalues []string) bool {
+	for _, rawvalue := range rawvalues {
+		if rawvalue != "" {
+			return false
+		}
+	}
+	return true
+}
+
 // setField writes values into a single struct field.
 // The timeFormat parameter carries the format option from the q tag (may be empty).
-func setField(f reflect.StructField, fv reflect.Value, values []string, timeFormat string) error {
+func setField(f reflect.StructField, fv reflect.Value, values []string, timeFormat Option[string]) error {
 	if len(values) == 0 {
 		return nil
 	}
@@ -152,17 +166,12 @@ func setField(f reflect.StructField, fv reflect.Value, values []string, timeForm
 	// We parse into a temporary value of the inner type by recursing into setField,
 	// then use UnmarshalYAML to set the Option value directly.
 	if _, isOption := fv.Type().MethodByName("IsSome"); isOption {
-		tmp := reflect.New(fv.Type().Field(0).Type).Elem()
-		if err := setField(f, tmp, values, timeFormat); err != nil {
-			return err
-		}
 		unmarshal := func(dest any) error {
-			// dest is **T (pointer to the *T that UnmarshalYAML allocated).
-			// We need to set *dest to point to our parsed tmp value.
-			ptr := reflect.New(tmp.Type())
-			ptr.Elem().Set(tmp)
-			reflect.ValueOf(dest).Elem().Set(ptr)
-			return nil
+			// dest is **T; allocate *T and parse into T directly
+			destVal := reflect.ValueOf(dest).Elem()         // *T
+			destVal.Set(reflect.New(destVal.Type().Elem())) // allocate T, set *T
+			inner := destVal.Elem()                         // T (the actual value to fill)
+			return setField(f, inner, values, timeFormat)
 		}
 		type yamlUnmarshaler interface {
 			UnmarshalYAML(func(any) error) error
@@ -183,9 +192,6 @@ func setField(f reflect.StructField, fv reflect.Value, values []string, timeForm
 
 	// handle time.Time fields
 	if fv.Type() == reflect.TypeFor[time.Time]() {
-		if timeFormat == "" {
-			panic("time format is missing for field " + f.Name)
-		}
 		t, err := parseTime(values[0], timeFormat)
 		if err != nil {
 			return err
@@ -301,20 +307,21 @@ func parseMapValues(values []string, keyType, valType reflect.Type) (reflect.Val
 	return m, nil
 }
 
-// parseTime parses a time string. Accepted formats are defined in opts.TimeFormats.
-func parseTime(s, timeFormat string) (time.Time, error) {
-	if timeFormat == UnixFormat {
+// parseTime parses a time string. Accepted non-unix formats are defined in opts.nonUnixTimeFormats.
+func parseTime(s string, timeFormat Option[string]) (time.Time, error) {
+	tf := timeFormat.UnwrapOrPanic("timeFormat should have been set")
+	if tf == unixTimeFormat {
 		n, err := strconv.ParseInt(s, 10, 64)
 		if err != nil {
-			return time.Time{}, fmt.Errorf("cannot parse %q as %s seconds: %w", s, UnixFormat, err)
+			return time.Time{}, fmt.Errorf("cannot parse %q as %s seconds: %w", s, unixTimeFormat, err)
 		}
 		return time.Unix(n, 0).UTC(), nil
 	}
 	// we checked this already when building knownOpts
-	layout := TimeFormats[timeFormat]
+	layout := nonUnixTimeFormats[tf]
 	t, err := time.Parse(layout, s)
 	if err != nil {
-		return time.Time{}, fmt.Errorf("cannot parse %q as %s: %w", s, timeFormat, err)
+		return time.Time{}, fmt.Errorf("cannot parse %q as %s: %w", s, tf, err)
 	}
 	return t, nil
 }

--- a/opts/parse.go
+++ b/opts/parse.go
@@ -64,6 +64,17 @@ import (
 //
 //	Quux string `q:"quux,required"`               // ?foo=bar --> error
 //
+// Bool fields can use a "value" option to participate in value-discriminant parsing.
+// Multiple bool fields sharing the same key each declare a specific value they match.
+// When the query contains that value for the key, the corresponding bool is set to true:
+//
+//	WithDetails       bool `q:"with,value:details"`
+//	WithSubresources  bool `q:"with,value:subresources"`
+//	WithSubcapacities bool `q:"with,value:subcapacities"`
+//
+// Given the query string ?with=details&with=subcapacities, WithDetails and
+// WithSubcapacities will be true while WithSubresources remains false.
+//
 // [option.Option]: https://pkg.go.dev/go.xyrillian.de/gg/option#Option
 func ParseQueryString[T any](query url.Values) (T, error) {
 	var opts T
@@ -80,7 +91,13 @@ func ParseQueryString[T any](query url.Values) (T, error) {
 		maybeTimeFormat   Option[string]
 		requiredAndUnseen bool
 	}
+	// valueField tracks a bool field with a value-discriminant tag.
+	type valueField struct {
+		fieldValue reflect.Value
+		value      string
+	}
 	knownOpts := make(map[string]optMeta, optsType.NumField())
+	valueFields := make(map[string][]valueField) // key → list of value-discriminant bools
 	for _, field := range reflect.VisibleFields(optsType) {
 		fieldValue := optsValue.FieldByIndex(field.Index)
 		qTag := field.Tag.Get("q")
@@ -94,9 +111,24 @@ func ParseQueryString[T any](query url.Values) (T, error) {
 		if qTag == "" {
 			panic(fmt.Sprintf(`expected %q to have a "q:"-tag`, field.Name))
 		}
-		optKey, maybeTimeFormat, required := parseQTag(qTag)
+		optKey, maybeTimeFormat, maybeValue, required := parseQTag(qTag)
 		if !fieldValue.CanSet() {
 			panic(fmt.Sprintf(`field %q is unexported and therefore cannot be set`, optKey))
+		}
+
+		// value-discriminant fields go into a separate structure
+		if value, ok := maybeValue.Unpack(); ok {
+			if fieldValue.Kind() != reflect.Bool {
+				panic(fmt.Sprintf(`field %q has "value:" option but is not a bool`, field.Name))
+			}
+			if maybeTimeFormat.IsSome() {
+				panic(fmt.Sprintf(`field %q cannot have both "value:" and "format:" options`, field.Name))
+			}
+			valueFields[optKey] = append(valueFields[optKey], valueField{
+				fieldValue: fieldValue,
+				value:      value,
+			})
+			continue
 		}
 
 		// check if format is set when required
@@ -114,11 +146,28 @@ func ParseQueryString[T any](query url.Values) (T, error) {
 
 	// iterate the query
 	for optKey, rawValues := range query {
+		// check value-discriminant fields first
+		if vfs, ok := valueFields[optKey]; ok {
+			for _, rawValue := range rawValues {
+				matched := false
+				for _, vf := range vfs {
+					if rawValue == vf.value {
+						vf.fieldValue.SetBool(true)
+						matched = true
+						break
+					}
+				}
+				if !matched {
+					return opts, fmt.Errorf("unknown value %q for query parameter %q", rawValue, optKey)
+				}
+			}
+			continue
+		}
+
 		meta, ok := knownOpts[optKey]
 		if !ok {
 			return opts, fmt.Errorf("unknown query parameter %q", optKey)
 		}
-		// now, just set the value of the field accordingly
 		err := setField(meta.structField, meta.fieldValue, rawValues, meta.maybeTimeFormat)
 		if err != nil {
 			return opts, fmt.Errorf("invalid value for query parameter %q: %w", optKey, err)

--- a/opts/parse.go
+++ b/opts/parse.go
@@ -19,7 +19,7 @@ import (
 // Fields are mapped by their "q" tag, mirroring the behavior of [opts.BuildQueryString].
 // For example:
 //
-//	type struct Something {
+//	type Something struct {
 //	   Bar string `q:"x_bar"`
 //	   Baz int    `q:"lorem_ipsum"`
 //	}

--- a/opts/parse.go
+++ b/opts/parse.go
@@ -340,17 +340,17 @@ func parseMapValues(values []string, mapType reflect.Type) (reflect.Value, error
 	m := reflect.MakeMapWithSize(mapType, len(values))
 	for _, raw := range values {
 		raw = strings.TrimSpace(raw)
-		kv := strings.SplitN(raw, ":", 2)
-		if len(kv) != 2 {
+		keyStr, valStr, ok := strings.Cut(raw, ":")
+		if !ok {
 			return reflect.Value{}, fmt.Errorf("invalid map entry %q: expected key:value", raw)
 		}
-		key, err := parseScalar(kv[0], mapType.Key())
+		key, err := parseScalar(keyStr, mapType.Key())
 		if err != nil {
-			return reflect.Value{}, fmt.Errorf("invalid map key %q: %w", kv[0], err)
+			return reflect.Value{}, fmt.Errorf("invalid map key %q: %w", keyStr, err)
 		}
-		val, err := parseScalar(kv[1], mapType.Elem())
+		val, err := parseScalar(valStr, mapType.Elem())
 		if err != nil {
-			return reflect.Value{}, fmt.Errorf("invalid map value %q: %w", kv[1], err)
+			return reflect.Value{}, fmt.Errorf("invalid map value %q: %w", valStr, err)
 		}
 		m.SetMapIndex(key, val)
 	}

--- a/opts/parse.go
+++ b/opts/parse.go
@@ -4,19 +4,16 @@
 package opts
 
 import (
-	"errors"
 	"fmt"
-	"net/http"
+	"net/url"
 	"reflect"
 	"slices"
 	"strconv"
 	"strings"
 	"time"
-
-	. "go.xyrillian.de/gg/option"
 )
 
-// ParseQueryString parses the query parameters of a *http.Request into an opt struct.
+// ParseQueryString parses the query parameters of url.Values into an opt struct.
 // Fields are mapped by their "q" tag, mirroring the behavior of [opts.BuildQueryString].
 // For example:
 //
@@ -25,7 +22,11 @@ import (
 //	   Baz int    `q:"lorem_ipsum"`
 //	}
 //
-// and a request with the query string "?x_bar=AAA&lorem_ipsum=BBB" will produce
+// and a request with the query string
+//
+//	?x_bar=AAA&lorem_ipsum=BBB
+//
+// will produce
 //
 //	result := Something{
 //	   Bar: "AAA",
@@ -37,25 +38,31 @@ import (
 // failure, missing required field) an error is returned. On success, the returned
 // opts are populated according to the http.Request.
 //
-// The parser supports all scalars except complex. Structs of scalars are supported
-// and special structs like time.Time. Additionally, it allows Slices (for multiple
-// values), option.Option (recommended for optional values) and pointers (as alternative
-// to option.Option) of these. Only map[string]string is supported as a map type.
+// The parser supports all scalars except complex. Additionally, it allows Slices
+// (for multiple values), [option.Option] (recommended for optional values) and
+// pointers (as alternative to [option.Option]) of these. Only map[string]string
+// is supported as a map type. Embedded structs and [time.Time] are supported.
 // Some inputs might work but are untested.
 //
 // Slice fields use repeated query parameters:
-// Foo []string `q:"foo"`                       // ?foo=a&foo=b
+//
+//	Foo []string `q:"foo"`                       // ?foo=a&foo=b
 //
 // Map fields accept plain repeated key:value pairs:
-// Bar map[string]string `q:"bar"`              // ?bar=k1:v1&bar=k2:v2
 //
-// time.Time fields support the formats RFC3339Nano, RFC3339, DateTime, Date, Unix.
-// A single `format` option can be set, to limit what the parser accepts:
-// Baz time.Time `q:"baz,format:RFC3339"`       // ?baz=1999-01-01T00:00:00
+//	Bar map[string]string `q:"bar"`              // ?bar=k1:v1&bar=k2:v2
 //
-// A `required` option can be set to define that a missing value will produce an error.
-// Quux string `q:"quux,required"`               // ?foo=bar --> error
-func ParseQueryString[T any](r *http.Request) (T, error) {
+// [time.Time] fields support the formats defined under [opts.TimeFormats].
+// A single "format" option must be set, to limit what the parser accepts:
+//
+//	Baz time.Time `q:"baz,format:RFC3339"`       // ?baz=1999-01-01T00:00:00
+//
+// A "required" option can be set to define that a missing value will produce an error.
+//
+//	Quux string `q:"quux,required"`               // ?foo=bar --> error
+//
+// [option.Option]: https://pkg.go.dev/go.xyrillian.de/gg/option#Option
+func ParseQueryString[T any](query url.Values) (T, error) {
 	var opts T
 	optsValue := reflect.ValueOf(&opts).Elem()
 	if optsValue.Kind() != reflect.Struct {
@@ -65,46 +72,53 @@ func ParseQueryString[T any](r *http.Request) (T, error) {
 	// build map of q-tags to field values
 	optsType := optsValue.Type()
 	type optMeta struct {
-		index             int
-		format            string // "" or time-formats
+		structField       reflect.StructField
+		fieldValue        reflect.Value
+		timeFormat        string // "" or time-formats
 		requiredAndUnseen bool
 	}
 	knownOpts := make(map[string]optMeta, optsType.NumField())
-	for i := range optsType.NumField() {
-		field := optsType.Field(i)
-		fieldValue := optsValue.Field(i)
+	for _, field := range reflect.VisibleFields(optsType) {
+		fieldValue := optsValue.FieldByIndex(field.Index)
 		qTag := field.Tag.Get("q")
+		if field.Anonymous {
+			// this is for struct embedding to work
+			if qTag != "" {
+				panic(fmt.Sprintf(`expected embedded struct %q to have no "q:"-tag`, field.Name))
+			}
+			continue
+		}
 		if qTag == "" {
 			panic(fmt.Sprintf(`expected %q to have a "q:"-tag`, field.Name))
 		}
-		optKey, format, required := parseQTag(qTag)
+		optKey, timeFormat, required := parseQTag(qTag)
 		if !fieldValue.CanSet() {
 			panic(fmt.Sprintf(`field %q is unexported and therefore cannot be set`, optKey))
 		}
-		// When format is set, it must be a known time format.
-		if _, ok := timeFormats[format]; format != "" && format != unixFormat && !ok {
-			return opts, fmt.Errorf("unsupported time format %q; accepted: %s, %s", format, supportedHumanReadableFormats, unixFormat)
+		// all known formats are currently timeFormats
+		if _, ok := TimeFormats[timeFormat]; timeFormat != "" && timeFormat != UnixFormat && !ok {
+			panic(fmt.Sprintf("unsupported time format %q; accepted: %s", timeFormat, supportedHumanReadableFormats))
 		}
 		knownOpts[optKey] = optMeta{
-			index:             i,
-			format:            format,
-			requiredAndUnseen: required}
+			structField:       field,
+			fieldValue:        fieldValue,
+			timeFormat:        timeFormat,
+			requiredAndUnseen: required,
+		}
 	}
 
 	// iterate the query
-	query := r.URL.Query()
 	for optKey, rawValues := range query {
 		meta, ok := knownOpts[optKey]
 		if !ok {
 			return opts, fmt.Errorf("unknown query parameter %q", optKey)
 		}
-		fieldValue := optsValue.Field(meta.index)
 		// now, just set the value of the field accordingly
-		err := setField(fieldValue, rawValues, meta.format)
+		err := setField(meta.structField, meta.fieldValue, rawValues, meta.timeFormat)
 		if err != nil {
 			return opts, fmt.Errorf("invalid value for query parameter %q: %w", optKey, err)
 		}
-		if !isZero(fieldValue) && meta.requiredAndUnseen {
+		if !isZero(meta.fieldValue) && meta.requiredAndUnseen {
 			meta.requiredAndUnseen = false
 			knownOpts[optKey] = meta
 		}
@@ -120,8 +134,12 @@ func ParseQueryString[T any](r *http.Request) (T, error) {
 }
 
 // setField writes values into a single struct field.
-// The format parameter carries the format option from the q tag (may be empty).
-func setField(fv reflect.Value, values []string, format string) error {
+// The timeFormat parameter carries the format option from the q tag (may be empty).
+func setField(f reflect.StructField, fv reflect.Value, values []string, timeFormat string) error {
+	if len(values) == 0 {
+		return nil
+	}
+
 	// unwrap pointer: allocate if nil
 	if fv.Kind() == reflect.Pointer {
 		if fv.IsNil() {
@@ -130,15 +148,12 @@ func setField(fv reflect.Value, values []string, format string) error {
 		fv = fv.Elem()
 	}
 
-	// Handle Option[T] fields: detected by the presence of an IsSome() bool method.
+	// handle Option[T] fields: detected by the presence of an IsSome() method
 	// We parse into a temporary value of the inner type by recursing into setField,
 	// then use UnmarshalYAML to set the Option value directly.
 	if _, isOption := fv.Type().MethodByName("IsSome"); isOption {
-		if len(values) == 0 {
-			return nil // leave as None (zero value)
-		}
 		tmp := reflect.New(fv.Type().Field(0).Type).Elem()
-		if err := setField(tmp, values, format); err != nil {
+		if err := setField(f, tmp, values, timeFormat); err != nil {
 			return err
 		}
 		unmarshal := func(dest any) error {
@@ -166,14 +181,12 @@ func setField(fv reflect.Value, values []string, format string) error {
 		}
 	}
 
-	// Handle time.Time fields: if a format is specified, use only that format;
-	// otherwise try multiple formats in order of specificity.
+	// handle time.Time fields
 	if fv.Type() == reflect.TypeFor[time.Time]() {
-		var formatOpt Option[string]
-		if format != "" {
-			formatOpt = Some(format)
+		if timeFormat == "" {
+			panic("time format is missing for field " + f.Name)
 		}
-		t, err := parseTime(values[0], formatOpt)
+		t, err := parseTime(values[0], timeFormat)
 		if err != nil {
 			return err
 		}
@@ -183,164 +196,125 @@ func setField(fv reflect.Value, values []string, format string) error {
 
 	// set scalars
 	switch fv.Kind() {
-	case reflect.String:
-		fv.SetString(values[0])
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		n, err := strconv.ParseInt(values[0], 10, fv.Type().Bits())
+	case reflect.String, reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Bool, reflect.Float32, reflect.Float64:
+		v, err := parseScalar(values[0], fv.Type())
 		if err != nil {
 			return err
 		}
-		fv.SetInt(n)
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		n, err := strconv.ParseUint(values[0], 10, fv.Type().Bits())
-		if err != nil {
-			return err
-		}
-		fv.SetUint(n)
-	case reflect.Bool:
-		b, err := strconv.ParseBool(values[0])
-		if err != nil {
-			return err
-		}
-		fv.SetBool(b)
-	case reflect.Float32, reflect.Float64:
-		f, err := strconv.ParseFloat(values[0], fv.Type().Bits())
-		if err != nil {
-			return err
-		}
-		fv.SetFloat(f)
+		fv.Set(v)
 	// set slices
 	case reflect.Slice:
 		elemType := fv.Type().Elem()
-		switch elemType.Kind() {
-		case reflect.String:
+		if elemType == reflect.TypeFor[time.Time]() {
 			sl := reflect.MakeSlice(fv.Type(), len(values), len(values))
 			for i, v := range values {
-				sl.Index(i).SetString(v)
-			}
-			fv.Set(sl)
-		case reflect.Bool:
-			sl := reflect.MakeSlice(fv.Type(), len(values), len(values))
-			for i, v := range values {
-				b, err := strconv.ParseBool(v)
-				if err != nil {
-					return fmt.Errorf("element %d: %w", i, err)
-				}
-				sl.Index(i).SetBool(b)
-			}
-			fv.Set(sl)
-		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-			sl := reflect.MakeSlice(fv.Type(), len(values), len(values))
-			for i, v := range values {
-				n, err := strconv.ParseInt(v, 10, elemType.Bits())
-				if err != nil {
-					return fmt.Errorf("element %d: %w", i, err)
-				}
-				sl.Index(i).SetInt(n)
-			}
-			fv.Set(sl)
-		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-			sl := reflect.MakeSlice(fv.Type(), len(values), len(values))
-			for i, v := range values {
-				n, err := strconv.ParseUint(v, 10, elemType.Bits())
-				if err != nil {
-					return fmt.Errorf("element %d: %w", i, err)
-				}
-				sl.Index(i).SetUint(n)
-			}
-			fv.Set(sl)
-		case reflect.Float32, reflect.Float64:
-			sl := reflect.MakeSlice(fv.Type(), len(values), len(values))
-			for i, v := range values {
-				f, err := strconv.ParseFloat(v, elemType.Bits())
-				if err != nil {
-					return fmt.Errorf("element %d: %w", i, err)
-				}
-				sl.Index(i).SetFloat(f)
-			}
-			fv.Set(sl)
-		case reflect.Struct:
-			if elemType != reflect.TypeFor[time.Time]() {
-				return fmt.Errorf("unsupported slice element type %s", elemType)
-			}
-			sl := reflect.MakeSlice(fv.Type(), len(values), len(values))
-			for i, v := range values {
-				var formatOpt Option[string]
-				if format != "" {
-					formatOpt = Some(format)
-				}
-				t, err := parseTime(v, formatOpt)
+				t, err := parseTime(v, timeFormat)
 				if err != nil {
 					return fmt.Errorf("element %d: %w", i, err)
 				}
 				sl.Index(i).Set(reflect.ValueOf(t))
 			}
 			fv.Set(sl)
-		default:
-			return fmt.Errorf("unsupported slice element type %s", elemType)
+		} else {
+			sl := reflect.MakeSlice(fv.Type(), len(values), len(values))
+			for i, v := range values {
+				elem, err := parseScalar(v, elemType)
+				if err != nil {
+					return fmt.Errorf("element %d: %w", i, err)
+				}
+				sl.Index(i).Set(elem)
+			}
+			fv.Set(sl)
 		}
 	// set maps
 	case reflect.Map:
-		if fv.Type().Key().Kind() != reflect.String || fv.Type().Elem().Kind() != reflect.String {
-			return errors.New("only map[string]string is supported")
-		}
-		m, err := parseMapValues(values)
+		m, err := parseMapValues(values, fv.Type().Key(), fv.Type().Elem())
 		if err != nil {
 			return err
 		}
-		fv.Set(reflect.ValueOf(m))
+		fv.Set(m)
 	default:
 		return fmt.Errorf("unsupported field type %s", fv.Type())
 	}
 	return nil
 }
 
-// parseMapValues parses a list of raw string values into a map[string]string.
-// It supports a repeated key:value notation (?m=k1:v1&m=k2:v2).
-func parseMapValues(values []string) (map[string]string, error) {
-	m := make(map[string]string)
+// parseScalar parses a single string into a reflect.Value of the given type.
+// Supported kinds: string, int*, uint*, float*, bool.
+func parseScalar(s string, t reflect.Type) (reflect.Value, error) {
+	v := reflect.New(t).Elem()
+	switch t.Kind() {
+	case reflect.String:
+		v.SetString(s)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		n, err := strconv.ParseInt(s, 10, t.Bits())
+		if err != nil {
+			return reflect.Value{}, err
+		}
+		v.SetInt(n)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		n, err := strconv.ParseUint(s, 10, t.Bits())
+		if err != nil {
+			return reflect.Value{}, err
+		}
+		v.SetUint(n)
+	case reflect.Float32, reflect.Float64:
+		f, err := strconv.ParseFloat(s, t.Bits())
+		if err != nil {
+			return reflect.Value{}, err
+		}
+		v.SetFloat(f)
+	case reflect.Bool:
+		b, err := strconv.ParseBool(s)
+		if err != nil {
+			return reflect.Value{}, err
+		}
+		v.SetBool(b)
+	default:
+		return reflect.Value{}, fmt.Errorf("unsupported type %s", t)
+	}
+	return v, nil
+}
+
+// parseMapValues parses a list of raw string values into a map with the given key and value types.
+// Each value must be in "key:value" notation (e.g. ?m=k1:v1&m=k2:v2).
+func parseMapValues(values []string, keyType, valType reflect.Type) (reflect.Value, error) {
+	m := reflect.MakeMap(reflect.MapOf(keyType, valType))
 	for _, raw := range values {
 		raw = strings.TrimSpace(raw)
 		kv := strings.SplitN(raw, ":", 2)
 		if len(kv) != 2 {
-			return nil, fmt.Errorf("invalid map entry %q: expected key:value", raw)
+			return reflect.Value{}, fmt.Errorf("invalid map entry %q: expected key:value", raw)
 		}
-		m[kv[0]] = kv[1]
+		key, err := parseScalar(kv[0], keyType)
+		if err != nil {
+			return reflect.Value{}, fmt.Errorf("invalid map key %q: %w", kv[0], err)
+		}
+		val, err := parseScalar(kv[1], valType)
+		if err != nil {
+			return reflect.Value{}, fmt.Errorf("invalid map value %q: %w", kv[1], err)
+		}
+		m.SetMapIndex(key, val)
 	}
 	return m, nil
 }
 
-// parseTime parses a time string. If format is Some, only that specific format
-// is accepted (one of "RFC3339Nano", "RFC3339", "DateTime", "DateOnly", "Unix").
-// If format is None, all formats are tried in order of specificity.
-func parseTime(s string, format Option[string]) (time.Time, error) {
-	if f, ok := format.Unpack(); ok {
-		if f == "Unix" {
-			n, err := strconv.ParseInt(s, 10, 64)
-			if err != nil {
-				return time.Time{}, fmt.Errorf("cannot parse %q as %s seconds: %w", s, unixFormat, err)
-			}
-			return time.Unix(n, 0).UTC(), nil
-		}
-		// we checked this already when building knownOpts
-		layout := timeFormats[f]
-		t, err := time.Parse(layout, s)
+// parseTime parses a time string. Accepted formats are defined in opts.TimeFormats.
+func parseTime(s, timeFormat string) (time.Time, error) {
+	if timeFormat == UnixFormat {
+		n, err := strconv.ParseInt(s, 10, 64)
 		if err != nil {
-			return time.Time{}, fmt.Errorf("cannot parse %q as %s: %w", s, f, err)
+			return time.Time{}, fmt.Errorf("cannot parse %q as %s seconds: %w", s, UnixFormat, err)
 		}
-		return t, nil
-	}
-
-	// No specific format — try all in order
-	for _, layout := range timeFormats {
-		t, err := time.Parse(layout, s)
-		if err == nil {
-			return t, nil
-		}
-	}
-	// Try Unix timestamp (non-negative seconds since epoch)
-	if n, err := strconv.ParseInt(s, 10, 64); err == nil {
 		return time.Unix(n, 0).UTC(), nil
 	}
-	return time.Time{}, fmt.Errorf("cannot parse %q as time; accepted: %s, %s", s, supportedHumanReadableFormats, unixFormat)
+	// we checked this already when building knownOpts
+	layout := TimeFormats[timeFormat]
+	t, err := time.Parse(layout, s)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("cannot parse %q as %s: %w", s, timeFormat, err)
+	}
+	return t, nil
 }

--- a/opts/parse.go
+++ b/opts/parse.go
@@ -188,9 +188,9 @@ func ParseQueryString[T any](query url.Values) (T, error) {
 }
 
 // isOnlyEmptyStrings checks if all rawValues are only emptyStrings.
-func isOnlyEmptyStrings(rawvalues []string) bool {
-	for _, rawvalue := range rawvalues {
-		if rawvalue != "" {
+func isOnlyEmptyStrings(rawValues []string) bool {
+	for _, rawValue := range rawValues {
+		if rawValue != "" {
 			return false
 		}
 	}

--- a/opts/parse.go
+++ b/opts/parse.go
@@ -4,7 +4,6 @@
 package opts
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -17,42 +16,48 @@ import (
 	. "go.xyrillian.de/gg/option"
 )
 
-// ParseQueryString parses the query parameters of a *http.Request into opts,
-// which must be a non-nil pointer to a struct. Fields are mapped by their "q"
-// struct tag, mirroring the behavior of gophercloud.BuildQueryString.
+// ParseQueryString parses the query parameters of a *http.Request into an opt struct.
+// Fields are mapped by their "q" tag, mirroring the behavior of [opts.BuildQueryString].
+// For example:
 //
-// On configuration errors (e.g. non-pointer opts, opts with non-q-tagged fields)
-// the function panics, so make sure to test your opts type thoroughly. On user
-// errors (unknown query parameter, type conversion failure, missing required field)
-// an error is returned. On success nil is returned and
-// opts is fully populated.
+//	type struct Something {
+//	   Bar string `q:"x_bar"`
+//	   Baz int    `q:"lorem_ipsum"`
+//	}
+//
+// and a request with the query string "?x_bar=AAA&lorem_ipsum=BBB" will produce
+//
+//	result := Something{
+//	   Bar: "AAA",
+//	   Baz: "BBB",
+//	}
+//
+// On configuration errors (e.g. non-struct opts, opts with non-q-tagged fields)
+// the function panics. On user errors (unknown query parameter, type conversion
+// failure, missing required field) an error is returned. On success, the returned
+// opts are populated according to the http.Request.
 //
 // The parser supports all scalars except complex. Structs of scalars are supported
 // and special structs like time.Time. Additionally, it allows Slices (for multiple
 // values), option.Option (recommended for optional values) and pointers (as alternative
 // to option.Option) of these. Only map[string]string is supported as a map type.
-// Some inputs might work but are untested, because they don't make sense to parse to:
-//   - option of map (map defaults to nil when missing)
-//   - option of slice (slice defaults to nil when missing)
-//   - option of struct (all values of the struct default)
+// Some inputs might work but are untested.
 //
-// Slice fields are supported in two formats (or a mixed form). When
-// "format:"-tag is set to "comma-separated" only the latter is accepted:
-// Foo []string `q:"foo"`                       // ?foo=a&foo=b  (repeated keys)
-// Bar []int    `q:"bar" format:"comma-separated"` // ?bar=1,2,3
+// Slice fields use repeated query parameters:
+// Foo []string `q:"foo"`                       // ?foo=a&foo=b
 //
-// map[string]string fields accept either the OpenStack brace notation
-// ({'k1':'v1', 'k2':'v2'}) or plain repeated key=value pairs (?m=k1:v1&m=k2:v2).
+// Map fields accept plain repeated key:value pairs:
+// Bar map[string]string `q:"bar"`              // ?bar=k1:v1&bar=k2:v2
 //
 // time.Time fields support the formats RFC3339Nano, RFC3339, DateTime, Date, Unix.
-// Likewise to slices, when no "format:"-tag is set, all are accepted:
-// baz time.Time `q:"baz" format:"RFC3339"`
-func ParseQueryString(r *http.Request, opts any) error {
-	optsValue := reflect.ValueOf(opts)
-	if optsValue.Kind() != reflect.Pointer || optsValue.IsNil() {
-		panic("expected opts to be a non-nil pointer")
-	}
-	optsValue = optsValue.Elem()
+// A single `format` option can be set, to limit what the parser accepts:
+// Baz time.Time `q:"baz,format:RFC3339"`       // ?baz=1999-01-01T00:00:00
+//
+// A `required` option can be set to define that a missing value will produce an error.
+// Quux string `q:"quux,required"`               // ?foo=bar --> error
+func ParseQueryString[T any](r *http.Request) (T, error) {
+	var opts T
+	optsValue := reflect.ValueOf(&opts).Elem()
 	if optsValue.Kind() != reflect.Struct {
 		panic("expected opts to point to a struct")
 	}
@@ -61,30 +66,29 @@ func ParseQueryString(r *http.Request, opts any) error {
 	optsType := optsValue.Type()
 	type optMeta struct {
 		index             int
-		format            string // "" or "comma-separated" or time-formats
+		format            string // "" or time-formats
 		requiredAndUnseen bool
 	}
 	knownOpts := make(map[string]optMeta, optsType.NumField())
 	for i := range optsType.NumField() {
 		field := optsType.Field(i)
 		fieldValue := optsValue.Field(i)
-		format := field.Tag.Get("format")
 		qTag := field.Tag.Get("q")
 		if qTag == "" {
 			panic(fmt.Sprintf(`expected %q to have a "q:"-tag`, field.Name))
 		}
-		optKey := strings.SplitN(qTag, ",", 2)[0]
+		optKey, format, required := parseQTag(qTag)
 		if !fieldValue.CanSet() {
 			panic(fmt.Sprintf(`field %q is unexported and therefore cannot be set`, optKey))
 		}
-		// When format:"..." is set, it's a time format.
-		if _, ok := timeFormats[format]; format != "" && format != commaSeparatedFormat && format != unixFormat && !ok {
-			return fmt.Errorf("unsupported time format %q; accepted: %s, %s", format, supportedHumanReadableFormats, unixFormat)
+		// When format is set, it must be a known time format.
+		if _, ok := timeFormats[format]; format != "" && format != unixFormat && !ok {
+			return opts, fmt.Errorf("unsupported time format %q; accepted: %s, %s", format, supportedHumanReadableFormats, unixFormat)
 		}
 		knownOpts[optKey] = optMeta{
 			index:             i,
 			format:            format,
-			requiredAndUnseen: field.Tag.Get("required") != ""}
+			requiredAndUnseen: required}
 	}
 
 	// iterate the query
@@ -92,42 +96,13 @@ func ParseQueryString(r *http.Request, opts any) error {
 	for optKey, rawValues := range query {
 		meta, ok := knownOpts[optKey]
 		if !ok {
-			// Check for dot-notation: struct.field
-			if prefix, suffix, found := strings.Cut(optKey, "."); found {
-				meta, ok = knownOpts[prefix]
-				if !ok {
-					return fmt.Errorf("unknown query parameter %q", optKey)
-				}
-				fieldValue := optsValue.Field(meta.index)
-				if err := setStructField(fieldValue, suffix, rawValues); err != nil {
-					return fmt.Errorf("invalid value for query parameter %q: %w", optKey, err)
-				}
-				continue
-			}
-			return fmt.Errorf("unknown query parameter %q", optKey)
+			return opts, fmt.Errorf("unknown query parameter %q", optKey)
 		}
 		fieldValue := optsValue.Field(meta.index)
-		// When format:"comma-separated" is set, reject repeated query keys.
-		if meta.format == commaSeparatedFormat && len(rawValues) > 1 {
-			return fmt.Errorf("query parameter %q uses %s format, but was provided as repeated keys", optKey, commaSeparatedFormat)
-		}
-		// rawValues has multiple entries for ?k=a&k=b, but we also want to accept ?k=a,b (and mixed).
-		var values []string
-		for _, rawValue := range rawValues {
-			rawValue = strings.TrimSpace(rawValue)
-			// Don't split OpenStack brace notation map values!
-			if strings.HasPrefix(rawValue, "{") && strings.HasSuffix(rawValue, "}") {
-				values = append(values, rawValue)
-				continue
-			}
-			for p := range strings.SplitSeq(rawValue, ",") {
-				values = append(values, strings.TrimSpace(p))
-			}
-		}
 		// now, just set the value of the field accordingly
-		err := setField(fieldValue, values, meta.format)
+		err := setField(fieldValue, rawValues, meta.format)
 		if err != nil {
-			return fmt.Errorf("invalid value for query parameter %q: %w", optKey, err)
+			return opts, fmt.Errorf("invalid value for query parameter %q: %w", optKey, err)
 		}
 		if !isZero(fieldValue) && meta.requiredAndUnseen {
 			meta.requiredAndUnseen = false
@@ -138,57 +113,14 @@ func ParseQueryString(r *http.Request, opts any) error {
 	// check that no required fields are missing
 	for optKey, meta := range knownOpts {
 		if meta.requiredAndUnseen {
-			return fmt.Errorf("missing value for query parameter %q", optKey)
+			return opts, fmt.Errorf("missing value for query parameter %q", optKey)
 		}
 	}
-	return nil
+	return opts, nil
 }
 
-// setStructField handles dot-notation query parameters for nested struct fields.
-// It finds the inner field by its q-tag suffix and dispatches to setField.
-func setStructField(fv reflect.Value, suffix string, rawValues []string) error {
-	// Dereference/allocate pointer
-	if fv.Kind() == reflect.Ptr { //nolint:govet // won't inline this...
-		if fv.IsNil() {
-			fv.Set(reflect.New(fv.Type().Elem()))
-		}
-		fv = fv.Elem()
-	}
-
-	if fv.Kind() != reflect.Struct {
-		return errors.New("field is not a struct")
-	}
-
-	return setInnerStructField(fv, suffix, rawValues)
-}
-
-// setInnerStructField finds a field within a struct by its q-tag and sets its value.
-func setInnerStructField(fv reflect.Value, suffix string, rawValues []string) error {
-	fvType := fv.Type()
-	for j := range fvType.NumField() {
-		innerField := fvType.Field(j)
-		innerQTag := strings.SplitN(innerField.Tag.Get("q"), ",", 2)[0]
-		if innerQTag == suffix {
-			// Build values the same way as the main loop
-			var values []string
-			for _, rawValue := range rawValues {
-				rawValue = strings.TrimSpace(rawValue)
-				if strings.HasPrefix(rawValue, "{") && strings.HasSuffix(rawValue, "}") {
-					values = append(values, rawValue)
-					continue
-				}
-				for p := range strings.SplitSeq(rawValue, ",") {
-					values = append(values, strings.TrimSpace(p))
-				}
-			}
-			return setField(fv.Field(j), values, innerField.Tag.Get("format"))
-		}
-	}
-	return fmt.Errorf("unknown field %q", suffix)
-}
-
-// setField writes values (already comma-expanded) into a single struct field.
-// The format parameter carries the value of the "format" struct tag (may be empty).
+// setField writes values into a single struct field.
+// The format parameter carries the format option from the q tag (may be empty).
 func setField(fv reflect.Value, values []string, format string) error {
 	// unwrap pointer: allocate if nil
 	if fv.Kind() == reflect.Pointer {
@@ -199,59 +131,28 @@ func setField(fv reflect.Value, values []string, format string) error {
 	}
 
 	// Handle Option[T] fields: detected by the presence of an IsSome() bool method.
-	// Option[T] implements json.Unmarshaler, so we parse values into JSON and unmarshal.
+	// We parse into a temporary value of the inner type by recursing into setField,
+	// then use UnmarshalYAML to set the Option value directly.
 	if _, isOption := fv.Type().MethodByName("IsSome"); isOption {
 		if len(values) == 0 {
 			return nil // leave as None (zero value)
 		}
-		innerType := fv.Type().Field(0).Type
-		innerKind := innerType.Kind()
-
-		var (
-			jsonBytes []byte
-			err       error
-		)
-		switch innerKind {
-		case reflect.Slice:
-			// Option[[]T] — build a JSON array from all values
-			elemKind := innerType.Elem().Kind()
-			elemBitSize := int(innerType.Elem().Size() * 8)
-			elems := make([]json.RawMessage, len(values))
-			for i, v := range values {
-				elems[i], err = scalarToJSON(v, elemKind, elemBitSize)
-				if err != nil {
-					return fmt.Errorf("element %d: %w", i, err)
-				}
-			}
-			jsonBytes, err = json.Marshal(elems)
-		case reflect.Struct:
-			// Option[time.Time] — parse with parseTime, then marshal to JSON for UnmarshalJSON
-			if innerType != reflect.TypeFor[time.Time]() {
-				return fmt.Errorf("unsupported Option inner type %s", innerType)
-			}
-			if len(values) > 1 {
-				return fmt.Errorf("expected a single value, got %d", len(values))
-			}
-			var formatOpt Option[string]
-			if format != "" {
-				formatOpt = Some(format)
-			}
-			t, parseErr := parseTime(values[0], formatOpt)
-			if parseErr != nil {
-				return parseErr
-			}
-			jsonBytes, err = json.Marshal(t)
-		default:
-			// Option[scalar] — must be exactly one value
-			if len(values) > 1 {
-				return fmt.Errorf("expected a single value, got %d", len(values))
-			}
-			jsonBytes, err = scalarToJSON(values[0], innerKind, int(innerType.Size()*8))
-		}
-		if err != nil {
+		tmp := reflect.New(fv.Type().Field(0).Type).Elem()
+		if err := setField(tmp, values, format); err != nil {
 			return err
 		}
-		return fv.Addr().Interface().(json.Unmarshaler).UnmarshalJSON(jsonBytes)
+		unmarshal := func(dest any) error {
+			// dest is **T (pointer to the *T that UnmarshalYAML allocated).
+			// We need to set *dest to point to our parsed tmp value.
+			ptr := reflect.New(tmp.Type())
+			ptr.Elem().Set(tmp)
+			reflect.ValueOf(dest).Elem().Set(ptr)
+			return nil
+		}
+		type yamlUnmarshaler interface {
+			UnmarshalYAML(func(any) error) error
+		}
+		return fv.Addr().Interface().(yamlUnmarshaler).UnmarshalYAML(unmarshal)
 	}
 
 	// some common error checks
@@ -395,28 +296,11 @@ func setField(fv reflect.Value, values []string, format string) error {
 }
 
 // parseMapValues parses a list of raw string values into a map[string]string.
-// It supports the OpenStack brace notation ({'k1':'v1', 'k2':'v2'}) and plain
-// repeated key:value notation (?m=k1:v1&m=k2:v2).
+// It supports a repeated key:value notation (?m=k1:v1&m=k2:v2).
 func parseMapValues(values []string) (map[string]string, error) {
 	m := make(map[string]string)
 	for _, raw := range values {
 		raw = strings.TrimSpace(raw)
-		// OpenStack brace notation: {'k1':'v1', 'k2':'v2'}
-		if strings.HasPrefix(raw, "{") && strings.HasSuffix(raw, "}") {
-			inner := raw[1 : len(raw)-1]
-			for pair := range strings.SplitSeq(inner, ",") {
-				pair = strings.TrimSpace(pair)
-				// strip surrounding single-quotes from key and value
-				pair = strings.Trim(pair, "'")
-				kv := strings.SplitN(pair, "':'", 2)
-				if len(kv) != 2 {
-					return nil, fmt.Errorf("invalid map entry %q", pair)
-				}
-				m[kv[0]] = kv[1]
-			}
-			continue
-		}
-		// Plain k:v notation (from repeated ?m=k1:v1&m=k2:v2 or comma-split)
 		kv := strings.SplitN(raw, ":", 2)
 		if len(kv) != 2 {
 			return nil, fmt.Errorf("invalid map entry %q: expected key:value", raw)
@@ -424,42 +308,6 @@ func parseMapValues(values []string) (map[string]string, error) {
 		m[kv[0]] = kv[1]
 	}
 	return m, nil
-}
-
-// scalarToJSON converts a raw string value to its JSON byte representation
-// based on the target type's reflect.Kind. bitSize controls the range check
-// for integer and float parsing (e.g. 8 for int8, 64 for int64/float64).
-func scalarToJSON(s string, kind reflect.Kind, bitSize int) ([]byte, error) {
-	switch kind {
-	case reflect.String:
-		return json.Marshal(s)
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		n, err := strconv.ParseInt(s, 10, bitSize)
-		if err != nil {
-			return nil, err
-		}
-		return json.Marshal(n)
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		n, err := strconv.ParseUint(s, 10, bitSize)
-		if err != nil {
-			return nil, err
-		}
-		return json.Marshal(n)
-	case reflect.Float32, reflect.Float64:
-		f, err := strconv.ParseFloat(s, bitSize)
-		if err != nil {
-			return nil, err
-		}
-		return json.Marshal(f)
-	case reflect.Bool:
-		b, err := strconv.ParseBool(s)
-		if err != nil {
-			return nil, err
-		}
-		return json.Marshal(b)
-	default:
-		return nil, fmt.Errorf("unsupported scalar type %s", kind)
-	}
 }
 
 // parseTime parses a time string. If format is Some, only that specific format

--- a/opts/parse.go
+++ b/opts/parse.go
@@ -26,13 +26,13 @@ import (
 //
 // and a request with the query string
 //
-//	?x_bar=AAA&lorem_ipsum=BBB
+//	?x_bar=AAA&lorem_ipsum=1
 //
 // will produce
 //
 //	result := Something{
 //	   Bar: "AAA",
-//	   Baz: "BBB",
+//	   Baz: 1,
 //	}
 //
 // On configuration errors (e.g. non-struct opts, opts with non-q-tagged fields)
@@ -42,8 +42,9 @@ import (
 //
 // The parser supports all scalars except complex. Additionally, it allows Slices
 // (for multiple values), [option.Option] (recommended for optional values) and
-// pointers (as alternative to [option.Option]) of these. Only map[string]string
-// is supported as a map type. Embedded structs and [time.Time] are supported.
+// pointers (as alternative to [option.Option]) of these. Maps are supported when
+// the key and value types are supported. Only selected structs work
+// (embedded structs and [time.Time]).
 // Some inputs might work but are untested.
 //
 // Slice fields use repeated query parameters:
@@ -54,7 +55,7 @@ import (
 //
 //	Bar map[string]string `q:"bar"`              // ?bar=k1:v1&bar=k2:v2
 //
-// [time.Time] fields support the formats RFC3339Nano, RFC3339, DateTime, Date, Unix
+// [time.Time] fields support the formats RFC3339Nano, RFC3339, DateTime, DateOnly, Unix
 // (seconds since epoch). A single "format" option must be set, to limit what the parser accepts:
 //
 //	Baz time.Time `q:"baz,format:RFC3339"`       // ?baz=1999-01-01T00:00:00
@@ -236,7 +237,7 @@ func setField(f reflect.StructField, fv reflect.Value, values []string, timeForm
 		}
 	// set maps
 	case reflect.Map:
-		m, err := parseMapValues(values, fv.Type().Key(), fv.Type().Elem())
+		m, err := parseMapValues(values, fv.Type())
 		if err != nil {
 			return err
 		}
@@ -284,21 +285,21 @@ func parseScalar(s string, t reflect.Type) (reflect.Value, error) {
 	return v, nil
 }
 
-// parseMapValues parses a list of raw string values into a map with the given key and value types.
+// parseMapValues parses a list of raw string values into a map with the given type.
 // Each value must be in "key:value" notation (e.g. ?m=k1:v1&m=k2:v2).
-func parseMapValues(values []string, keyType, valType reflect.Type) (reflect.Value, error) {
-	m := reflect.MakeMap(reflect.MapOf(keyType, valType))
+func parseMapValues(values []string, mapType reflect.Type) (reflect.Value, error) {
+	m := reflect.MakeMapWithSize(mapType, len(values))
 	for _, raw := range values {
 		raw = strings.TrimSpace(raw)
 		kv := strings.SplitN(raw, ":", 2)
 		if len(kv) != 2 {
 			return reflect.Value{}, fmt.Errorf("invalid map entry %q: expected key:value", raw)
 		}
-		key, err := parseScalar(kv[0], keyType)
+		key, err := parseScalar(kv[0], mapType.Key())
 		if err != nil {
 			return reflect.Value{}, fmt.Errorf("invalid map key %q: %w", kv[0], err)
 		}
-		val, err := parseScalar(kv[1], valType)
+		val, err := parseScalar(kv[1], mapType.Elem())
 		if err != nil {
 			return reflect.Value{}, fmt.Errorf("invalid map value %q: %w", kv[1], err)
 		}

--- a/opts/parse.go
+++ b/opts/parse.go
@@ -1,0 +1,498 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package opts
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"reflect"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	. "go.xyrillian.de/gg/option"
+)
+
+// ParseQueryString parses the query parameters of a *http.Request into opts,
+// which must be a non-nil pointer to a struct. Fields are mapped by their "q"
+// struct tag, mirroring the behavior of gophercloud.BuildQueryString.
+//
+// On configuration errors (e.g. non-pointer opts, opts with non-q-tagged fields)
+// the function panics, so make sure to test your opts type thoroughly. On user
+// errors (unknown query parameter, type conversion failure, missing required field)
+// an error is returned. On success nil is returned and
+// opts is fully populated.
+//
+// The parser supports all scalars except complex. Structs of scalars are supported
+// and special structs like time.Time. Additionally, it allows Slices (for multiple
+// values), option.Option (recommended for optional values) and pointers (as alternative
+// to option.Option) of these. Only map[string]string is supported as a map type.
+// Some inputs might work but are untested, because they don't make sense to parse to:
+//   - option of map (map defaults to nil when missing)
+//   - option of slice (slice defaults to nil when missing)
+//   - option of struct (all values of the struct default)
+//
+// Slice fields are supported in two formats (or a mixed form). When
+// "format:"-tag is set to "comma-separated" only the latter is accepted:
+// Foo []string `q:"foo"`                       // ?foo=a&foo=b  (repeated keys)
+// Bar []int    `q:"bar" format:"comma-separated"` // ?bar=1,2,3
+//
+// map[string]string fields accept either the OpenStack brace notation
+// ({'k1':'v1', 'k2':'v2'}) or plain repeated key=value pairs (?m=k1:v1&m=k2:v2).
+//
+// time.Time fields support the formats RFC3339Nano, RFC3339, DateTime, Date, Unix.
+// Likewise to slices, when no "format:"-tag is set, all are accepted:
+// baz time.Time `q:"baz" format:"RFC3339"`
+func ParseQueryString(r *http.Request, opts any) error {
+	optsValue := reflect.ValueOf(opts)
+	if optsValue.Kind() != reflect.Pointer || optsValue.IsNil() {
+		panic("expected opts to be a non-nil pointer")
+	}
+	optsValue = optsValue.Elem()
+	if optsValue.Kind() != reflect.Struct {
+		panic("expected opts to point to a struct")
+	}
+
+	// build map of q-tags to field values
+	optsType := optsValue.Type()
+	type optMeta struct {
+		index             int
+		format            string // "" or "comma-separated" or time-formats
+		requiredAndUnseen bool
+	}
+	knownOpts := make(map[string]optMeta, optsType.NumField())
+	for i := range optsType.NumField() {
+		field := optsType.Field(i)
+		fieldValue := optsValue.Field(i)
+		format := field.Tag.Get("format")
+		qTag := field.Tag.Get("q")
+		if qTag == "" {
+			panic(fmt.Sprintf(`expected %q to have a "q:"-tag`, field.Name))
+		}
+		optKey := strings.SplitN(qTag, ",", 2)[0]
+		if !fieldValue.CanSet() {
+			panic(fmt.Sprintf(`field %q is unexported and therefore cannot be set`, optKey))
+		}
+		// When format:"..." is set, it's a time format.
+		if _, ok := timeFormats[format]; format != "" && format != commaSeparatedFormat && format != unixFormat && !ok {
+			return fmt.Errorf("unsupported time format %q; accepted: %s, %s", format, supportedHumanReadableFormats, unixFormat)
+		}
+		knownOpts[optKey] = optMeta{
+			index:             i,
+			format:            format,
+			requiredAndUnseen: field.Tag.Get("required") != ""}
+	}
+
+	// iterate the query
+	query := r.URL.Query()
+	for optKey, rawValues := range query {
+		meta, ok := knownOpts[optKey]
+		if !ok {
+			// Check for dot-notation: struct.field
+			if prefix, suffix, found := strings.Cut(optKey, "."); found {
+				meta, ok = knownOpts[prefix]
+				if !ok {
+					return fmt.Errorf("unknown query parameter %q", optKey)
+				}
+				fieldValue := optsValue.Field(meta.index)
+				if err := setStructField(fieldValue, suffix, rawValues); err != nil {
+					return fmt.Errorf("invalid value for query parameter %q: %w", optKey, err)
+				}
+				continue
+			}
+			return fmt.Errorf("unknown query parameter %q", optKey)
+		}
+		fieldValue := optsValue.Field(meta.index)
+		// When format:"comma-separated" is set, reject repeated query keys.
+		if meta.format == commaSeparatedFormat && len(rawValues) > 1 {
+			return fmt.Errorf("query parameter %q uses %s format, but was provided as repeated keys", optKey, commaSeparatedFormat)
+		}
+		// rawValues has multiple entries for ?k=a&k=b, but we also want to accept ?k=a,b (and mixed).
+		var values []string
+		for _, rawValue := range rawValues {
+			rawValue = strings.TrimSpace(rawValue)
+			// Don't split OpenStack brace notation map values!
+			if strings.HasPrefix(rawValue, "{") && strings.HasSuffix(rawValue, "}") {
+				values = append(values, rawValue)
+				continue
+			}
+			for p := range strings.SplitSeq(rawValue, ",") {
+				values = append(values, strings.TrimSpace(p))
+			}
+		}
+		// now, just set the value of the field accordingly
+		err := setField(fieldValue, values, meta.format)
+		if err != nil {
+			return fmt.Errorf("invalid value for query parameter %q: %w", optKey, err)
+		}
+		if !isZero(fieldValue) && meta.requiredAndUnseen {
+			meta.requiredAndUnseen = false
+			knownOpts[optKey] = meta
+		}
+	}
+
+	// check that no required fields are missing
+	for optKey, meta := range knownOpts {
+		if meta.requiredAndUnseen {
+			return fmt.Errorf("missing value for query parameter %q", optKey)
+		}
+	}
+	return nil
+}
+
+// setStructField handles dot-notation query parameters for nested struct fields.
+// It finds the inner field by its q-tag suffix and dispatches to setField.
+func setStructField(fv reflect.Value, suffix string, rawValues []string) error {
+	// Dereference/allocate pointer
+	if fv.Kind() == reflect.Ptr { //nolint:govet // won't inline this...
+		if fv.IsNil() {
+			fv.Set(reflect.New(fv.Type().Elem()))
+		}
+		fv = fv.Elem()
+	}
+
+	if fv.Kind() != reflect.Struct {
+		return errors.New("field is not a struct")
+	}
+
+	return setInnerStructField(fv, suffix, rawValues)
+}
+
+// setInnerStructField finds a field within a struct by its q-tag and sets its value.
+func setInnerStructField(fv reflect.Value, suffix string, rawValues []string) error {
+	fvType := fv.Type()
+	for j := range fvType.NumField() {
+		innerField := fvType.Field(j)
+		innerQTag := strings.SplitN(innerField.Tag.Get("q"), ",", 2)[0]
+		if innerQTag == suffix {
+			// Build values the same way as the main loop
+			var values []string
+			for _, rawValue := range rawValues {
+				rawValue = strings.TrimSpace(rawValue)
+				if strings.HasPrefix(rawValue, "{") && strings.HasSuffix(rawValue, "}") {
+					values = append(values, rawValue)
+					continue
+				}
+				for p := range strings.SplitSeq(rawValue, ",") {
+					values = append(values, strings.TrimSpace(p))
+				}
+			}
+			return setField(fv.Field(j), values, innerField.Tag.Get("format"))
+		}
+	}
+	return fmt.Errorf("unknown field %q", suffix)
+}
+
+// setField writes values (already comma-expanded) into a single struct field.
+// The format parameter carries the value of the "format" struct tag (may be empty).
+func setField(fv reflect.Value, values []string, format string) error {
+	// unwrap pointer: allocate if nil
+	if fv.Kind() == reflect.Pointer {
+		if fv.IsNil() {
+			fv.Set(reflect.New(fv.Type().Elem()))
+		}
+		fv = fv.Elem()
+	}
+
+	// Handle Option[T] fields: detected by the presence of an IsSome() bool method.
+	// Option[T] implements json.Unmarshaler, so we parse values into JSON and unmarshal.
+	if _, isOption := fv.Type().MethodByName("IsSome"); isOption {
+		if len(values) == 0 {
+			return nil // leave as None (zero value)
+		}
+		innerType := fv.Type().Field(0).Type
+		innerKind := innerType.Kind()
+
+		var (
+			jsonBytes []byte
+			err       error
+		)
+		switch innerKind {
+		case reflect.Slice:
+			// Option[[]T] — build a JSON array from all values
+			elemKind := innerType.Elem().Kind()
+			elemBitSize := int(innerType.Elem().Size() * 8)
+			elems := make([]json.RawMessage, len(values))
+			for i, v := range values {
+				elems[i], err = scalarToJSON(v, elemKind, elemBitSize)
+				if err != nil {
+					return fmt.Errorf("element %d: %w", i, err)
+				}
+			}
+			jsonBytes, err = json.Marshal(elems)
+		case reflect.Struct:
+			// Option[time.Time] — parse with parseTime, then marshal to JSON for UnmarshalJSON
+			if innerType != reflect.TypeFor[time.Time]() {
+				return fmt.Errorf("unsupported Option inner type %s", innerType)
+			}
+			if len(values) > 1 {
+				return fmt.Errorf("expected a single value, got %d", len(values))
+			}
+			var formatOpt Option[string]
+			if format != "" {
+				formatOpt = Some(format)
+			}
+			t, parseErr := parseTime(values[0], formatOpt)
+			if parseErr != nil {
+				return parseErr
+			}
+			jsonBytes, err = json.Marshal(t)
+		default:
+			// Option[scalar] — must be exactly one value
+			if len(values) > 1 {
+				return fmt.Errorf("expected a single value, got %d", len(values))
+			}
+			jsonBytes, err = scalarToJSON(values[0], innerKind, int(innerType.Size()*8))
+		}
+		if err != nil {
+			return err
+		}
+		return fv.Addr().Interface().(json.Unmarshaler).UnmarshalJSON(jsonBytes)
+	}
+
+	// some common error checks
+	if slices.Contains([]reflect.Kind{reflect.String, reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint,
+		reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Bool, reflect.Float32, reflect.Float64}, fv.Kind()) || fv.Type() == reflect.TypeFor[time.Time]() {
+		if len(values) == 0 {
+			return nil
+		}
+		if len(values) > 1 {
+			return fmt.Errorf("expected a single value, got %d", len(values))
+		}
+	}
+
+	// Handle time.Time fields: if a format is specified, use only that format;
+	// otherwise try multiple formats in order of specificity.
+	if fv.Type() == reflect.TypeFor[time.Time]() {
+		var formatOpt Option[string]
+		if format != "" {
+			formatOpt = Some(format)
+		}
+		t, err := parseTime(values[0], formatOpt)
+		if err != nil {
+			return err
+		}
+		fv.Set(reflect.ValueOf(t))
+		return nil
+	}
+
+	// set scalars
+	switch fv.Kind() {
+	case reflect.String:
+		fv.SetString(values[0])
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		n, err := strconv.ParseInt(values[0], 10, fv.Type().Bits())
+		if err != nil {
+			return err
+		}
+		fv.SetInt(n)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		n, err := strconv.ParseUint(values[0], 10, fv.Type().Bits())
+		if err != nil {
+			return err
+		}
+		fv.SetUint(n)
+	case reflect.Bool:
+		b, err := strconv.ParseBool(values[0])
+		if err != nil {
+			return err
+		}
+		fv.SetBool(b)
+	case reflect.Float32, reflect.Float64:
+		f, err := strconv.ParseFloat(values[0], fv.Type().Bits())
+		if err != nil {
+			return err
+		}
+		fv.SetFloat(f)
+	// set slices
+	case reflect.Slice:
+		elemType := fv.Type().Elem()
+		switch elemType.Kind() {
+		case reflect.String:
+			sl := reflect.MakeSlice(fv.Type(), len(values), len(values))
+			for i, v := range values {
+				sl.Index(i).SetString(v)
+			}
+			fv.Set(sl)
+		case reflect.Bool:
+			sl := reflect.MakeSlice(fv.Type(), len(values), len(values))
+			for i, v := range values {
+				b, err := strconv.ParseBool(v)
+				if err != nil {
+					return fmt.Errorf("element %d: %w", i, err)
+				}
+				sl.Index(i).SetBool(b)
+			}
+			fv.Set(sl)
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			sl := reflect.MakeSlice(fv.Type(), len(values), len(values))
+			for i, v := range values {
+				n, err := strconv.ParseInt(v, 10, elemType.Bits())
+				if err != nil {
+					return fmt.Errorf("element %d: %w", i, err)
+				}
+				sl.Index(i).SetInt(n)
+			}
+			fv.Set(sl)
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			sl := reflect.MakeSlice(fv.Type(), len(values), len(values))
+			for i, v := range values {
+				n, err := strconv.ParseUint(v, 10, elemType.Bits())
+				if err != nil {
+					return fmt.Errorf("element %d: %w", i, err)
+				}
+				sl.Index(i).SetUint(n)
+			}
+			fv.Set(sl)
+		case reflect.Float32, reflect.Float64:
+			sl := reflect.MakeSlice(fv.Type(), len(values), len(values))
+			for i, v := range values {
+				f, err := strconv.ParseFloat(v, elemType.Bits())
+				if err != nil {
+					return fmt.Errorf("element %d: %w", i, err)
+				}
+				sl.Index(i).SetFloat(f)
+			}
+			fv.Set(sl)
+		case reflect.Struct:
+			if elemType != reflect.TypeFor[time.Time]() {
+				return fmt.Errorf("unsupported slice element type %s", elemType)
+			}
+			sl := reflect.MakeSlice(fv.Type(), len(values), len(values))
+			for i, v := range values {
+				var formatOpt Option[string]
+				if format != "" {
+					formatOpt = Some(format)
+				}
+				t, err := parseTime(v, formatOpt)
+				if err != nil {
+					return fmt.Errorf("element %d: %w", i, err)
+				}
+				sl.Index(i).Set(reflect.ValueOf(t))
+			}
+			fv.Set(sl)
+		default:
+			return fmt.Errorf("unsupported slice element type %s", elemType)
+		}
+	// set maps
+	case reflect.Map:
+		if fv.Type().Key().Kind() != reflect.String || fv.Type().Elem().Kind() != reflect.String {
+			return errors.New("only map[string]string is supported")
+		}
+		m, err := parseMapValues(values)
+		if err != nil {
+			return err
+		}
+		fv.Set(reflect.ValueOf(m))
+	default:
+		return fmt.Errorf("unsupported field type %s", fv.Type())
+	}
+	return nil
+}
+
+// parseMapValues parses a list of raw string values into a map[string]string.
+// It supports the OpenStack brace notation ({'k1':'v1', 'k2':'v2'}) and plain
+// repeated key:value notation (?m=k1:v1&m=k2:v2).
+func parseMapValues(values []string) (map[string]string, error) {
+	m := make(map[string]string)
+	for _, raw := range values {
+		raw = strings.TrimSpace(raw)
+		// OpenStack brace notation: {'k1':'v1', 'k2':'v2'}
+		if strings.HasPrefix(raw, "{") && strings.HasSuffix(raw, "}") {
+			inner := raw[1 : len(raw)-1]
+			for pair := range strings.SplitSeq(inner, ",") {
+				pair = strings.TrimSpace(pair)
+				// strip surrounding single-quotes from key and value
+				pair = strings.Trim(pair, "'")
+				kv := strings.SplitN(pair, "':'", 2)
+				if len(kv) != 2 {
+					return nil, fmt.Errorf("invalid map entry %q", pair)
+				}
+				m[kv[0]] = kv[1]
+			}
+			continue
+		}
+		// Plain k:v notation (from repeated ?m=k1:v1&m=k2:v2 or comma-split)
+		kv := strings.SplitN(raw, ":", 2)
+		if len(kv) != 2 {
+			return nil, fmt.Errorf("invalid map entry %q: expected key:value", raw)
+		}
+		m[kv[0]] = kv[1]
+	}
+	return m, nil
+}
+
+// scalarToJSON converts a raw string value to its JSON byte representation
+// based on the target type's reflect.Kind. bitSize controls the range check
+// for integer and float parsing (e.g. 8 for int8, 64 for int64/float64).
+func scalarToJSON(s string, kind reflect.Kind, bitSize int) ([]byte, error) {
+	switch kind {
+	case reflect.String:
+		return json.Marshal(s)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		n, err := strconv.ParseInt(s, 10, bitSize)
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(n)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		n, err := strconv.ParseUint(s, 10, bitSize)
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(n)
+	case reflect.Float32, reflect.Float64:
+		f, err := strconv.ParseFloat(s, bitSize)
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(f)
+	case reflect.Bool:
+		b, err := strconv.ParseBool(s)
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(b)
+	default:
+		return nil, fmt.Errorf("unsupported scalar type %s", kind)
+	}
+}
+
+// parseTime parses a time string. If format is Some, only that specific format
+// is accepted (one of "RFC3339Nano", "RFC3339", "DateTime", "DateOnly", "Unix").
+// If format is None, all formats are tried in order of specificity.
+func parseTime(s string, format Option[string]) (time.Time, error) {
+	if f, ok := format.Unpack(); ok {
+		if f == "Unix" {
+			n, err := strconv.ParseInt(s, 10, 64)
+			if err != nil {
+				return time.Time{}, fmt.Errorf("cannot parse %q as %s seconds: %w", s, unixFormat, err)
+			}
+			return time.Unix(n, 0).UTC(), nil
+		}
+		// we checked this already when building knownOpts
+		layout := timeFormats[f]
+		t, err := time.Parse(layout, s)
+		if err != nil {
+			return time.Time{}, fmt.Errorf("cannot parse %q as %s: %w", s, f, err)
+		}
+		return t, nil
+	}
+
+	// No specific format — try all in order
+	for _, layout := range timeFormats {
+		t, err := time.Parse(layout, s)
+		if err == nil {
+			return t, nil
+		}
+	}
+	// Try Unix timestamp (non-negative seconds since epoch)
+	if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return time.Unix(n, 0).UTC(), nil
+	}
+	return time.Time{}, fmt.Errorf("cannot parse %q as time; accepted: %s, %s", s, supportedHumanReadableFormats, unixFormat)
+}

--- a/opts/parse.go
+++ b/opts/parse.go
@@ -91,13 +91,8 @@ func ParseQueryString[T any](query url.Values) (T, error) {
 		maybeTimeFormat   Option[string]
 		requiredAndUnseen bool
 	}
-	// valueField tracks a bool field with a value-discriminant tag.
-	type valueField struct {
-		fieldValue reflect.Value
-		value      string
-	}
 	knownOpts := make(map[string]optMeta, optsType.NumField())
-	valueFields := make(map[string][]valueField) // key → list of value-discriminant bools
+	valueFields := make(map[string]map[string]reflect.Value) // key → list of value-discriminant bools
 	for _, field := range reflect.VisibleFields(optsType) {
 		fieldValue := optsValue.FieldByIndex(field.Index)
 		qTag := field.Tag.Get("q")
@@ -124,10 +119,10 @@ func ParseQueryString[T any](query url.Values) (T, error) {
 			if maybeTimeFormat.IsSome() {
 				panic(fmt.Sprintf(`field %q cannot have both "value:" and "format:" options`, field.Name))
 			}
-			valueFields[optKey] = append(valueFields[optKey], valueField{
-				fieldValue: fieldValue,
-				value:      value,
-			})
+			if _, keyExists := valueFields[optKey]; !keyExists {
+				valueFields[optKey] = make(map[string]reflect.Value)
+			}
+			valueFields[optKey][value] = fieldValue
 			continue
 		}
 
@@ -154,19 +149,13 @@ func ParseQueryString[T any](query url.Values) (T, error) {
 	// iterate the query
 	for optKey, rawValues := range query {
 		// check value-discriminant fields first
-		if vfs, ok := valueFields[optKey]; ok {
+		if _, isValueField := valueFields[optKey]; isValueField {
 			for _, rawValue := range rawValues {
-				matched := false
-				for _, vf := range vfs {
-					if rawValue == vf.value {
-						vf.fieldValue.SetBool(true)
-						matched = true
-						break
-					}
+				if valueField, matched := valueFields[optKey][rawValue]; matched {
+					valueField.SetBool(true)
+					continue
 				}
-				if !matched {
-					return opts, fmt.Errorf("unknown value %q for query parameter %q", rawValue, optKey)
-				}
+				return opts, fmt.Errorf("unknown value %q for query parameter %q", rawValue, optKey)
 			}
 			continue
 		}

--- a/opts/parse.go
+++ b/opts/parse.go
@@ -113,7 +113,7 @@ func ParseQueryString[T any](query url.Values) (T, error) {
 		}
 		optKey, maybeTimeFormat, maybeValue, required := parseQTag(qTag)
 		if !fieldValue.CanSet() {
-			panic(fmt.Sprintf(`field %q is unexported and therefore cannot be set`, optKey))
+			panic(fmt.Sprintf(`field %q is unexported and therefore cannot be set`, field.Name))
 		}
 
 		// value-discriminant fields go into a separate structure
@@ -141,6 +141,13 @@ func ParseQueryString[T any](query url.Values) (T, error) {
 			fieldValue:        fieldValue,
 			maybeTimeFormat:   maybeTimeFormat,
 			requiredAndUnseen: required,
+		}
+	}
+
+	// keys may not be used for both regular fields and value-discriminant fields
+	for optKey := range valueFields {
+		if _, exists := knownOpts[optKey]; exists {
+			panic(fmt.Sprintf(`key %q cannot be declared as both a regular field and a value-discriminant field`, optKey))
 		}
 	}
 

--- a/opts/parse_test.go
+++ b/opts/parse_test.go
@@ -229,13 +229,16 @@ func TestOptParserHappyPaths(t *testing.T) {
 func checkParsingPanic(t *testing.T, panicMsg string, fn func()) {
 	t.Helper()
 	defer func() {
+		t.Helper()
 		r := recover()
 		if r == nil {
 			t.Errorf("expected panic %q, but function did not panic", panicMsg)
+			return
 		}
 		got, ok := r.(string)
 		if !ok {
 			t.Errorf("expected panic with string %q, but got non-string panic: %v", panicMsg, r)
+			return
 		}
 		if got != panicMsg {
 			t.Errorf("expected panic: %s, but got: %s", panicMsg, got)
@@ -273,6 +276,17 @@ func TestOptParserErrors(t *testing.T) {
 	}
 	checkParsingPanic(t, `expected embedded struct "EmbeddedOpts" to have no "q:"-tag`, func() {
 		opts.ParseQueryString[testEmbeddedQTagOpts](r.URL.Query()) //nolint:errcheck // won't get to this part
+	})
+
+	// contradictory field declarations
+	type testFieldNameCollisionOpts struct {
+		Scope   string   `q:"scope"`
+		With    []string `q:"with"`
+		WithFoo bool     `q:"with,value:foo"`
+		WithBar bool     `q:"with,value:bar"`
+	}
+	checkParsingPanic(t, `key "with" cannot be declared as both a regular field and a value-discriminant field`, func() {
+		opts.ParseQueryString[testFieldNameCollisionOpts](r.URL.Query()) //nolint:errcheck // won't get to this part
 	})
 
 	// missing required parameter

--- a/opts/parse_test.go
+++ b/opts/parse_test.go
@@ -19,14 +19,8 @@ import (
 	"github.com/sapcc/go-api-declarations/opts"
 )
 
-type testInnerOpts struct {
-	Name string `q:"name"`
-	Age  int    `q:"age"`
-}
-
 type testOpts struct {
 	StringMap      map[string]string `q:"string_map"`
-	Struct         testInnerOpts     `q:"struct"`
 	Bool           bool              `q:"bool"`
 	Time           time.Time         `q:"time"`
 	String         string            `q:"string"`
@@ -42,7 +36,6 @@ type testOpts struct {
 	Uint64         uint64            `q:"uint64"`
 	Float32        float32           `q:"float32"`
 	Float64        float64           `q:"float64"`
-	PointerStruct  *testInnerOpts    `q:"pointer_struct"`
 	PointerBool    *bool             `q:"pointer_bool"`
 	PointerTime    *time.Time        `q:"pointer_time"`
 	PointerString  *string           `q:"pointer_string"`
@@ -92,9 +85,8 @@ type testOpts struct {
 
 func checkParsingHappyPath(t *testing.T, variable, query string, result testOpts) {
 	t.Helper()
-	var to testOpts
 	r := httptest.NewRequest(http.MethodGet, "/some/unimportant/path"+query, http.NoBody)
-	err := opts.ParseQueryString(r, &to)
+	to, err := opts.ParseQueryString[testOpts](r)
 	if err != nil {
 		t.Fatal(variable + ": " + err.Error())
 	}
@@ -105,19 +97,9 @@ func TestOptParserHappyPaths(t *testing.T) {
 	// empty query
 	checkParsingHappyPath(t, "empty opts", "", testOpts{})
 
-	// map plain k:v notation
-	checkParsingHappyPath(t, "string_map plain", "?string_map=k1:v1&string_map=k2:v2",
+	// map
+	checkParsingHappyPath(t, "string_map", "?string_map=k1:v1&string_map=k2:v2",
 		testOpts{StringMap: map[string]string{"k1": "v1", "k2": "v2"}})
-	// map OpenStack brace notation
-	checkParsingHappyPath(t, "string_map brace", "?string_map={'k1':'v1','k2':'v2'}",
-		testOpts{StringMap: map[string]string{"k1": "v1", "k2": "v2"}})
-	// map mixed notation (brace + plain k:v in separate query params)
-	checkParsingHappyPath(t, "string_map mixed", "?string_map={'k1':'v1','k2':'v2'}&string_map=k3:v3",
-		testOpts{StringMap: map[string]string{"k1": "v1", "k2": "v2", "k3": "v3"}})
-
-	// struct
-	checkParsingHappyPath(t, "struct", "?struct.name=foo&struct.age=42",
-		testOpts{Struct: testInnerOpts{Name: "foo", Age: 42}})
 
 	// time
 	checkParsingHappyPath(t, "time RFC3339Nano", "?time=2000-01-01T00:00:00.000000000Z",
@@ -145,14 +127,6 @@ func TestOptParserHappyPaths(t *testing.T) {
 
 	// time slice
 	checkParsingHappyPath(t, "slice time (all formats)", "?time_slice=2000-01-01T00:00:00.000000000Z&time_slice=2001-01-01T00:00:00Z&time_slice=2002-01-01%2000:00:00&time_slice=2003-01-01&time_slice=1072915200",
-		testOpts{TimeSlice: []time.Time{
-			time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC),
-			time.Date(2001, 1, 1, 0, 0, 0, 0, time.UTC),
-			time.Date(2002, 1, 1, 0, 0, 0, 0, time.UTC),
-			time.Date(2003, 1, 1, 0, 0, 0, 0, time.UTC),
-			time.Date(2004, 1, 1, 0, 0, 0, 0, time.UTC),
-		}})
-	checkParsingHappyPath(t, "slice time (all formats, comma-separated)", "?time_slice=2000-01-01T00:00:00.000000000Z,2001-01-01T00:00:00Z,2002-01-01%2000:00:00,2003-01-01,1072915200",
 		testOpts{TimeSlice: []time.Time{
 			time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC),
 			time.Date(2001, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -190,8 +164,6 @@ func TestOptParserHappyPaths(t *testing.T) {
 	checkParsingHappyPath(t, "float64", "?float64=2.5", testOpts{Float64: 2.5})
 
 	// pointer scalars
-	checkParsingHappyPath(t, "pointer_struct", "?pointer_struct.name=bar&pointer_struct.age=7",
-		testOpts{PointerStruct: &testInnerOpts{Name: "bar", Age: 7}})
 	checkParsingHappyPath(t, "pointer_bool", "?pointer_bool=true", testOpts{PointerBool: new(true)})
 	checkParsingHappyPath(t, "pointer_string", "?pointer_string=world", testOpts{PointerString: new("world")})
 	checkParsingHappyPath(t, "pointer_int", "?pointer_int=7", testOpts{PointerInt: new(7)})
@@ -207,64 +179,34 @@ func TestOptParserHappyPaths(t *testing.T) {
 	checkParsingHappyPath(t, "pointer_float32", "?pointer_float32=3.14", testOpts{PointerFloat32: new(float32(3.14))})
 	checkParsingHappyPath(t, "pointer_float64", "?pointer_float64=2.718", testOpts{PointerFloat64: new(2.718)})
 
-	// slices (repeated keys)
-	checkParsingHappyPath(t, "bool_slice repeated", "?bool_slice=true&bool_slice=false&bool_slice=true",
+	// slices
+	checkParsingHappyPath(t, "bool_slice", "?bool_slice=true&bool_slice=false&bool_slice=true",
 		testOpts{BoolSlice: []bool{true, false, true}})
-	checkParsingHappyPath(t, "string_slice repeated", "?string_slice=a&string_slice=b&string_slice=c",
+	checkParsingHappyPath(t, "string_slice", "?string_slice=a&string_slice=b&string_slice=c",
 		testOpts{StringSlice: []string{"a", "b", "c"}})
-	checkParsingHappyPath(t, "int_slice repeated", "?int_slice=1&int_slice=2&int_slice=3",
+	checkParsingHappyPath(t, "int_slice", "?int_slice=1&int_slice=2&int_slice=3",
 		testOpts{IntSlice: []int{1, 2, 3}})
-	checkParsingHappyPath(t, "int8_slice repeated", "?int8_slice=1&int8_slice=2&int8_slice=3",
+	checkParsingHappyPath(t, "int8_slice", "?int8_slice=1&int8_slice=2&int8_slice=3",
 		testOpts{Int8Slice: []int8{1, 2, 3}})
-	checkParsingHappyPath(t, "int16_slice repeated", "?int16_slice=1&int16_slice=2&int16_slice=3",
+	checkParsingHappyPath(t, "int16_slice", "?int16_slice=1&int16_slice=2&int16_slice=3",
 		testOpts{Int16Slice: []int16{1, 2, 3}})
-	checkParsingHappyPath(t, "int32_slice repeated", "?int32_slice=1&int32_slice=2&int32_slice=3",
+	checkParsingHappyPath(t, "int32_slice", "?int32_slice=1&int32_slice=2&int32_slice=3",
 		testOpts{Int32Slice: []int32{1, 2, 3}})
-	checkParsingHappyPath(t, "int64_slice repeated", "?int64_slice=1&int64_slice=2&int64_slice=3",
+	checkParsingHappyPath(t, "int64_slice", "?int64_slice=1&int64_slice=2&int64_slice=3",
 		testOpts{Int64Slice: []int64{1, 2, 3}})
-	checkParsingHappyPath(t, "uint_slice repeated", "?uint_slice=1&uint_slice=2&uint_slice=3",
+	checkParsingHappyPath(t, "uint_slice", "?uint_slice=1&uint_slice=2&uint_slice=3",
 		testOpts{UintSlice: []uint{1, 2, 3}})
-	checkParsingHappyPath(t, "uint8_slice repeated", "?uint8_slice=1&uint8_slice=2&uint8_slice=3",
+	checkParsingHappyPath(t, "uint8_slice", "?uint8_slice=1&uint8_slice=2&uint8_slice=3",
 		testOpts{Uint8Slice: []uint8{1, 2, 3}})
-	checkParsingHappyPath(t, "uint16_slice repeated", "?uint16_slice=1&uint16_slice=2&uint16_slice=3",
+	checkParsingHappyPath(t, "uint16_slice", "?uint16_slice=1&uint16_slice=2&uint16_slice=3",
 		testOpts{Uint16Slice: []uint16{1, 2, 3}})
-	checkParsingHappyPath(t, "uint32_slice repeated", "?uint32_slice=1&uint32_slice=2&uint32_slice=3",
+	checkParsingHappyPath(t, "uint32_slice", "?uint32_slice=1&uint32_slice=2&uint32_slice=3",
 		testOpts{Uint32Slice: []uint32{1, 2, 3}})
-	checkParsingHappyPath(t, "uint64_slice repeated", "?uint64_slice=1&uint64_slice=2&uint64_slice=3",
+	checkParsingHappyPath(t, "uint64_slice", "?uint64_slice=1&uint64_slice=2&uint64_slice=3",
 		testOpts{Uint64Slice: []uint64{1, 2, 3}})
-	checkParsingHappyPath(t, "float32_slice repeated", "?float32_slice=1.5&float32_slice=2.5",
+	checkParsingHappyPath(t, "float32_slice", "?float32_slice=1.5&float32_slice=2.5",
 		testOpts{Float32Slice: []float32{1.5, 2.5}})
-	checkParsingHappyPath(t, "float64_slice repeated", "?float64_slice=1.5&float64_slice=2.5",
-		testOpts{Float64Slice: []float64{1.5, 2.5}})
-
-	// slices (comma-separated)
-	checkParsingHappyPath(t, "bool_slice comma", "?bool_slice=true,false,true",
-		testOpts{BoolSlice: []bool{true, false, true}})
-	checkParsingHappyPath(t, "string_slice comma", "?string_slice=a,b,c",
-		testOpts{StringSlice: []string{"a", "b", "c"}})
-	checkParsingHappyPath(t, "int_slice comma", "?int_slice=1,2,3",
-		testOpts{IntSlice: []int{1, 2, 3}})
-	checkParsingHappyPath(t, "int8_slice comma", "?int8_slice=1,2,3",
-		testOpts{Int8Slice: []int8{1, 2, 3}})
-	checkParsingHappyPath(t, "int16_slice comma", "?int16_slice=1,2,3",
-		testOpts{Int16Slice: []int16{1, 2, 3}})
-	checkParsingHappyPath(t, "int32_slice comma", "?int32_slice=1,2,3",
-		testOpts{Int32Slice: []int32{1, 2, 3}})
-	checkParsingHappyPath(t, "int64_slice comma", "?int64_slice=1,2,3",
-		testOpts{Int64Slice: []int64{1, 2, 3}})
-	checkParsingHappyPath(t, "uint_slice comma", "?uint_slice=1,2,3",
-		testOpts{UintSlice: []uint{1, 2, 3}})
-	checkParsingHappyPath(t, "uint8_slice comma", "?uint8_slice=1,2,3",
-		testOpts{Uint8Slice: []uint8{1, 2, 3}})
-	checkParsingHappyPath(t, "uint16_slice comma", "?uint16_slice=1,2,3",
-		testOpts{Uint16Slice: []uint16{1, 2, 3}})
-	checkParsingHappyPath(t, "uint32_slice comma", "?uint32_slice=1,2,3",
-		testOpts{Uint32Slice: []uint32{1, 2, 3}})
-	checkParsingHappyPath(t, "uint64_slice comma", "?uint64_slice=1,2,3",
-		testOpts{Uint64Slice: []uint64{1, 2, 3}})
-	checkParsingHappyPath(t, "float32_slice comma", "?float32_slice=1.5,2.5",
-		testOpts{Float32Slice: []float32{1.5, 2.5}})
-	checkParsingHappyPath(t, "float64_slice comma", "?float64_slice=1.5,2.5",
+	checkParsingHappyPath(t, "float64_slice", "?float64_slice=1.5&float64_slice=2.5",
 		testOpts{Float64Slice: []float64{1.5, 2.5}})
 
 	// Option scalars
@@ -308,43 +250,36 @@ func checkParsingPanic(t *testing.T, panicMsg string, fn func()) {
 
 func checkParsingError(t *testing.T, query, errMsg string) {
 	t.Helper()
-	var to testOpts
 	r := httptest.NewRequest(http.MethodGet, "/some/unimportant/path"+query, http.NoBody)
-	resultingError := opts.ParseQueryString(r, &to)
+	_, resultingError := opts.ParseQueryString[testOpts](r)
 	th.AssertErr(t, errMsg, resultingError)
 }
 
 func TestOptParserErrors(t *testing.T) {
-	// non-pointer or non-struct input (these panic)
+	// non-struct type parameter (panics)
 	r := httptest.NewRequest(http.MethodGet, "/some/unimportant/path", http.NoBody)
-	checkParsingPanic(t, "expected opts to be a non-nil pointer", func() {
-		opts.ParseQueryString(r, nil) //nolint:errcheck // won't get to this part
-	})
-	checkParsingPanic(t, "expected opts to be a non-nil pointer", func() {
-		opts.ParseQueryString(r, testOpts{}) //nolint:errcheck // won't get to this part
-	})
 	checkParsingPanic(t, "expected opts to point to a struct", func() {
-		opts.ParseQueryString(r, new(5)) //nolint:errcheck // won't get to this part
+		opts.ParseQueryString[int](r) //nolint:errcheck // won't get to this part
 	})
 
-	// incompatible struct (panics)
+	// missing q-tag (panics)
 	type testNonOpts struct {
 		String string `yaml:"string"`
 	}
 	checkParsingPanic(t, `expected "String" to have a "q:"-tag`, func() {
-		opts.ParseQueryString(r, &testNonOpts{}) //nolint:errcheck // won't get to this part
+		opts.ParseQueryString[testNonOpts](r) //nolint:errcheck // won't get to this part
 	})
 
 	// missing required parameter
 	type testStringRequiredOpts struct {
-		String string `q:"string" required:"true"`
+		String string `q:"string,required"`
 	}
-	resultingError := opts.ParseQueryString(r, &testStringRequiredOpts{})
+	_, resultingError := opts.ParseQueryString[testStringRequiredOpts](r)
 	th.AssertErr(t, `missing value for query parameter "string"`, resultingError)
 	type testStringSliceRequiredOpts struct {
-		StringSlice []string `q:"string_slice" required:"true"`
+		StringSlice []string `q:"string_slice,required"`
 	}
-	resultingError = opts.ParseQueryString(r, &testStringSliceRequiredOpts{})
+	_, resultingError = opts.ParseQueryString[testStringSliceRequiredOpts](r)
 	th.AssertErr(t, `missing value for query parameter "string_slice"`, resultingError)
 
 	// unknown parameter
@@ -370,28 +305,17 @@ func TestOptParserErrors(t *testing.T) {
 	checkParsingError(t, "?option_bool=foo", `invalid value for query parameter "option_bool": strconv.ParseBool: parsing "foo": invalid syntax`)
 	checkParsingError(t, "?bool_slice=foo", `invalid value for query parameter "bool_slice": element 0: strconv.ParseBool: parsing "foo": invalid syntax`)
 
-	// wrong format: slices
-	r = httptest.NewRequest(http.MethodGet, "/some/unimportant/path?string_slice=a&string_slice=b", http.NoBody)
-	type testSliceFormatOpts struct {
-		StringSlice []string `q:"string_slice" format:"comma-separated"`
-	}
-	resultingError = opts.ParseQueryString(r, &testSliceFormatOpts{})
-	th.AssertErr(t, `query parameter "string_slice" uses comma-separated format, but was provided as repeated keys`, resultingError)
-	r = httptest.NewRequest(http.MethodGet, "/some/unimportant/path?string_slice=a,b,c,d&string_slice=e", http.NoBody)
-	resultingError = opts.ParseQueryString(r, &testSliceFormatOpts{})
-	th.AssertErr(t, `query parameter "string_slice" uses comma-separated format, but was provided as repeated keys`, resultingError)
-
 	// wrong format: time
 	r = httptest.NewRequest(http.MethodGet, "/some/unimportant/path?time=2000-01-01%2000:00", http.NoBody)
 	type testImpossibleTimeFormatOpts struct {
-		Time time.Time `q:"time" format:"foo"`
+		Time time.Time `q:"time,format:foo"`
 	}
-	resultingError = opts.ParseQueryString(r, &testImpossibleTimeFormatOpts{})
+	_, resultingError = opts.ParseQueryString[testImpossibleTimeFormatOpts](r)
 	th.AssertErr(t, `unsupported time format "foo"; accepted: DateOnly, DateTime, RFC3339, RFC3339Nano, Unix`, resultingError)
 	type testTimeFormatOpts struct {
-		Time time.Time `q:"time" format:"RFC3339"`
+		Time time.Time `q:"time,format:RFC3339"`
 	}
-	resultingError = opts.ParseQueryString(r, &testTimeFormatOpts{})
+	_, resultingError = opts.ParseQueryString[testTimeFormatOpts](r)
 	th.AssertErr(t, `invalid value for query parameter "time": cannot parse "2000-01-01 00:00" as RFC3339: parsing time "2000-01-01 00:00" as "2006-01-02T15:04:05Z07:00": cannot parse " 00:00" as "T"`, resultingError)
 
 	// wrong type: numbers

--- a/opts/parse_test.go
+++ b/opts/parse_test.go
@@ -25,69 +25,72 @@ type EmbeddedOpts struct {
 
 type testOpts struct {
 	EmbeddedOpts
-	StringMap      map[string]string `q:"string_map"`
-	IntStringMap   map[int]string    `q:"int_string_map"`
-	StringIntMap   map[string]int    `q:"string_int_map"`
-	Bool           bool              `q:"bool"`
-	Time           time.Time         `q:"time,format:RFC3339"`
-	String         string            `q:"string"`
-	Int            int               `q:"int"`
-	Int8           int8              `q:"int8"`
-	Int16          int16             `q:"int16"`
-	Int32          int32             `q:"int32"`
-	Int64          int64             `q:"int64"`
-	Uint           uint              `q:"uint"`
-	Uint8          uint8             `q:"uint8"`
-	Uint16         uint16            `q:"uint16"`
-	Uint32         uint32            `q:"uint32"`
-	Uint64         uint64            `q:"uint64"`
-	Float32        float32           `q:"float32"`
-	Float64        float64           `q:"float64"`
-	PointerBool    *bool             `q:"pointer_bool"`
-	PointerTime    *time.Time        `q:"pointer_time,format:RFC3339"`
-	PointerString  *string           `q:"pointer_string"`
-	PointerInt     *int              `q:"pointer_int"`
-	PointerInt8    *int8             `q:"pointer_int8"`
-	PointerInt16   *int16            `q:"pointer_int16"`
-	PointerInt32   *int32            `q:"pointer_int32"`
-	PointerInt64   *int64            `q:"pointer_int64"`
-	PointerUint    *uint             `q:"pointer_uint"`
-	PointerUint8   *uint8            `q:"pointer_uint8"`
-	PointerUint16  *uint16           `q:"pointer_uint16"`
-	PointerUint32  *uint32           `q:"pointer_uint32"`
-	PointerUint64  *uint64           `q:"pointer_uint64"`
-	PointerFloat32 *float32          `q:"pointer_float32"`
-	PointerFloat64 *float64          `q:"pointer_float64"`
-	BoolSlice      []bool            `q:"bool_slice"`
-	TimeSlice      []time.Time       `q:"time_slice,format:RFC3339"`
-	StringSlice    []string          `q:"string_slice"`
-	IntSlice       []int             `q:"int_slice"`
-	Int8Slice      []int8            `q:"int8_slice"`
-	Int16Slice     []int16           `q:"int16_slice"`
-	Int32Slice     []int32           `q:"int32_slice"`
-	Int64Slice     []int64           `q:"int64_slice"`
-	UintSlice      []uint            `q:"uint_slice"`
-	Uint8Slice     []uint8           `q:"uint8_slice"`
-	Uint16Slice    []uint16          `q:"uint16_slice"`
-	Uint32Slice    []uint32          `q:"uint32_slice"`
-	Uint64Slice    []uint64          `q:"uint64_slice"`
-	Float32Slice   []float32         `q:"float32_slice"`
-	Float64Slice   []float64         `q:"float64_slice"`
-	OptionBool     Option[bool]      `q:"option_bool"`
-	OptionTime     Option[time.Time] `q:"option_time,format:RFC3339"`
-	OptionString   Option[string]    `q:"option_string"`
-	OptionInt      Option[int]       `q:"option_int"`
-	OptionInt8     Option[int8]      `q:"option_int8"`
-	OptionInt16    Option[int16]     `q:"option_int16"`
-	OptionInt32    Option[int32]     `q:"option_int32"`
-	OptionInt64    Option[int64]     `q:"option_int64"`
-	OptionUint     Option[uint]      `q:"option_uint"`
-	OptionUint8    Option[uint8]     `q:"option_uint8"`
-	OptionUint16   Option[uint16]    `q:"option_uint16"`
-	OptionUint32   Option[uint32]    `q:"option_uint32"`
-	OptionUint64   Option[uint64]    `q:"option_uint64"`
-	OptionFloat32  Option[float32]   `q:"option_float32"`
-	OptionFloat64  Option[float64]   `q:"option_float64"`
+	StringMap         map[string]string `q:"string_map"`
+	IntStringMap      map[int]string    `q:"int_string_map"`
+	StringIntMap      map[string]int    `q:"string_int_map"`
+	Bool              bool              `q:"bool"`
+	Time              time.Time         `q:"time,format:RFC3339"`
+	String            string            `q:"string"`
+	Int               int               `q:"int"`
+	Int8              int8              `q:"int8"`
+	Int16             int16             `q:"int16"`
+	Int32             int32             `q:"int32"`
+	Int64             int64             `q:"int64"`
+	Uint              uint              `q:"uint"`
+	Uint8             uint8             `q:"uint8"`
+	Uint16            uint16            `q:"uint16"`
+	Uint32            uint32            `q:"uint32"`
+	Uint64            uint64            `q:"uint64"`
+	Float32           float32           `q:"float32"`
+	Float64           float64           `q:"float64"`
+	PointerBool       *bool             `q:"pointer_bool"`
+	PointerTime       *time.Time        `q:"pointer_time,format:RFC3339"`
+	PointerString     *string           `q:"pointer_string"`
+	PointerInt        *int              `q:"pointer_int"`
+	PointerInt8       *int8             `q:"pointer_int8"`
+	PointerInt16      *int16            `q:"pointer_int16"`
+	PointerInt32      *int32            `q:"pointer_int32"`
+	PointerInt64      *int64            `q:"pointer_int64"`
+	PointerUint       *uint             `q:"pointer_uint"`
+	PointerUint8      *uint8            `q:"pointer_uint8"`
+	PointerUint16     *uint16           `q:"pointer_uint16"`
+	PointerUint32     *uint32           `q:"pointer_uint32"`
+	PointerUint64     *uint64           `q:"pointer_uint64"`
+	PointerFloat32    *float32          `q:"pointer_float32"`
+	PointerFloat64    *float64          `q:"pointer_float64"`
+	BoolSlice         []bool            `q:"bool_slice"`
+	TimeSlice         []time.Time       `q:"time_slice,format:RFC3339"`
+	StringSlice       []string          `q:"string_slice"`
+	IntSlice          []int             `q:"int_slice"`
+	Int8Slice         []int8            `q:"int8_slice"`
+	Int16Slice        []int16           `q:"int16_slice"`
+	Int32Slice        []int32           `q:"int32_slice"`
+	Int64Slice        []int64           `q:"int64_slice"`
+	UintSlice         []uint            `q:"uint_slice"`
+	Uint8Slice        []uint8           `q:"uint8_slice"`
+	Uint16Slice       []uint16          `q:"uint16_slice"`
+	Uint32Slice       []uint32          `q:"uint32_slice"`
+	Uint64Slice       []uint64          `q:"uint64_slice"`
+	Float32Slice      []float32         `q:"float32_slice"`
+	Float64Slice      []float64         `q:"float64_slice"`
+	OptionBool        Option[bool]      `q:"option_bool"`
+	OptionTime        Option[time.Time] `q:"option_time,format:RFC3339"`
+	OptionString      Option[string]    `q:"option_string"`
+	OptionInt         Option[int]       `q:"option_int"`
+	OptionInt8        Option[int8]      `q:"option_int8"`
+	OptionInt16       Option[int16]     `q:"option_int16"`
+	OptionInt32       Option[int32]     `q:"option_int32"`
+	OptionInt64       Option[int64]     `q:"option_int64"`
+	OptionUint        Option[uint]      `q:"option_uint"`
+	OptionUint8       Option[uint8]     `q:"option_uint8"`
+	OptionUint16      Option[uint16]    `q:"option_uint16"`
+	OptionUint32      Option[uint32]    `q:"option_uint32"`
+	OptionUint64      Option[uint64]    `q:"option_uint64"`
+	OptionFloat32     Option[float32]   `q:"option_float32"`
+	OptionFloat64     Option[float64]   `q:"option_float64"`
+	WithDetails       bool              `q:"with,value:details"`
+	WithSubresources  bool              `q:"with,value:subresources"`
+	WithSubcapacities bool              `q:"with,value:subcapacities"`
 }
 
 func checkParsingHappyPath(t *testing.T, variable, query string, result testOpts) {
@@ -217,6 +220,10 @@ func TestOptParserHappyPaths(t *testing.T) {
 	// multiple fields at once
 	checkParsingHappyPath(t, "multiple fields", "?bool=true&string=hi&int=5&option_string=world",
 		testOpts{Bool: true, String: "hi", Int: 5, OptionString: Some("world")})
+
+	// value-discriminant bools
+	checkParsingHappyPath(t, "value-discriminant bools", "?with=details&with=subcapacities",
+		testOpts{WithDetails: true, WithSubresources: false, WithSubcapacities: true})
 }
 
 func checkParsingPanic(t *testing.T, panicMsg string, fn func()) {

--- a/opts/parse_test.go
+++ b/opts/parse_test.go
@@ -314,7 +314,7 @@ func TestOptParserErrors(t *testing.T) {
 	type testMissingTimeFormatOpts struct {
 		Time time.Time `q:"time"`
 	}
-	checkParsingPanic(t, `time format is missing for field Time`, func() {
+	checkParsingPanic(t, `time format is missing for field "Time"`, func() {
 		opts.ParseQueryString[testMissingTimeFormatOpts](r.URL.Query()) //nolint:errcheck // won't get to this part
 	})
 

--- a/opts/parse_test.go
+++ b/opts/parse_test.go
@@ -1,0 +1,666 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package opts_test
+
+import (
+	"fmt"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	. "go.xyrillian.de/gg/option"
+
+	th "github.com/sapcc/go-api-declarations/internal/testhelper"
+	"github.com/sapcc/go-api-declarations/opts"
+)
+
+type testInnerOpts struct {
+	Name string `q:"name"`
+	Age  int    `q:"age"`
+}
+
+type testOpts struct {
+	StringMap      map[string]string `q:"string_map"`
+	Struct         testInnerOpts     `q:"struct"`
+	Bool           bool              `q:"bool"`
+	Time           time.Time         `q:"time"`
+	String         string            `q:"string"`
+	Int            int               `q:"int"`
+	Int8           int8              `q:"int8"`
+	Int16          int16             `q:"int16"`
+	Int32          int32             `q:"int32"`
+	Int64          int64             `q:"int64"`
+	Uint           uint              `q:"uint"`
+	Uint8          uint8             `q:"uint8"`
+	Uint16         uint16            `q:"uint16"`
+	Uint32         uint32            `q:"uint32"`
+	Uint64         uint64            `q:"uint64"`
+	Float32        float32           `q:"float32"`
+	Float64        float64           `q:"float64"`
+	PointerStruct  *testInnerOpts    `q:"pointer_struct"`
+	PointerBool    *bool             `q:"pointer_bool"`
+	PointerTime    *time.Time        `q:"pointer_time"`
+	PointerString  *string           `q:"pointer_string"`
+	PointerInt     *int              `q:"pointer_int"`
+	PointerInt8    *int8             `q:"pointer_int8"`
+	PointerInt16   *int16            `q:"pointer_int16"`
+	PointerInt32   *int32            `q:"pointer_int32"`
+	PointerInt64   *int64            `q:"pointer_int64"`
+	PointerUint    *uint             `q:"pointer_uint"`
+	PointerUint8   *uint8            `q:"pointer_uint8"`
+	PointerUint16  *uint16           `q:"pointer_uint16"`
+	PointerUint32  *uint32           `q:"pointer_uint32"`
+	PointerUint64  *uint64           `q:"pointer_uint64"`
+	PointerFloat32 *float32          `q:"pointer_float32"`
+	PointerFloat64 *float64          `q:"pointer_float64"`
+	BoolSlice      []bool            `q:"bool_slice"`
+	TimeSlice      []time.Time       `q:"time_slice"`
+	StringSlice    []string          `q:"string_slice"`
+	IntSlice       []int             `q:"int_slice"`
+	Int8Slice      []int8            `q:"int8_slice"`
+	Int16Slice     []int16           `q:"int16_slice"`
+	Int32Slice     []int32           `q:"int32_slice"`
+	Int64Slice     []int64           `q:"int64_slice"`
+	UintSlice      []uint            `q:"uint_slice"`
+	Uint8Slice     []uint8           `q:"uint8_slice"`
+	Uint16Slice    []uint16          `q:"uint16_slice"`
+	Uint32Slice    []uint32          `q:"uint32_slice"`
+	Uint64Slice    []uint64          `q:"uint64_slice"`
+	Float32Slice   []float32         `q:"float32_slice"`
+	Float64Slice   []float64         `q:"float64_slice"`
+	OptionBool     Option[bool]      `q:"option_bool"`
+	OptionTime     Option[time.Time] `q:"option_time"`
+	OptionString   Option[string]    `q:"option_string"`
+	OptionInt      Option[int]       `q:"option_int"`
+	OptionInt8     Option[int8]      `q:"option_int8"`
+	OptionInt16    Option[int16]     `q:"option_int16"`
+	OptionInt32    Option[int32]     `q:"option_int32"`
+	OptionInt64    Option[int64]     `q:"option_int64"`
+	OptionUint     Option[uint]      `q:"option_uint"`
+	OptionUint8    Option[uint8]     `q:"option_uint8"`
+	OptionUint16   Option[uint16]    `q:"option_uint16"`
+	OptionUint32   Option[uint32]    `q:"option_uint32"`
+	OptionUint64   Option[uint64]    `q:"option_uint64"`
+	OptionFloat32  Option[float32]   `q:"option_float32"`
+	OptionFloat64  Option[float64]   `q:"option_float64"`
+}
+
+func checkParsingHappyPath(t *testing.T, variable, query string, result testOpts) {
+	t.Helper()
+	var to testOpts
+	r := httptest.NewRequest(http.MethodGet, "/some/unimportant/path"+query, http.NoBody)
+	err := opts.ParseQueryString(r, &to)
+	if err != nil {
+		t.Fatal(variable + ": " + err.Error())
+	}
+	th.CheckDeepEquals(t, result, to)
+}
+
+func TestOptParserHappyPaths(t *testing.T) {
+	// empty query
+	checkParsingHappyPath(t, "empty opts", "", testOpts{})
+
+	// map plain k:v notation
+	checkParsingHappyPath(t, "string_map plain", "?string_map=k1:v1&string_map=k2:v2",
+		testOpts{StringMap: map[string]string{"k1": "v1", "k2": "v2"}})
+	// map OpenStack brace notation
+	checkParsingHappyPath(t, "string_map brace", "?string_map={'k1':'v1','k2':'v2'}",
+		testOpts{StringMap: map[string]string{"k1": "v1", "k2": "v2"}})
+	// map mixed notation (brace + plain k:v in separate query params)
+	checkParsingHappyPath(t, "string_map mixed", "?string_map={'k1':'v1','k2':'v2'}&string_map=k3:v3",
+		testOpts{StringMap: map[string]string{"k1": "v1", "k2": "v2", "k3": "v3"}})
+
+	// struct
+	checkParsingHappyPath(t, "struct", "?struct.name=foo&struct.age=42",
+		testOpts{Struct: testInnerOpts{Name: "foo", Age: 42}})
+
+	// time
+	checkParsingHappyPath(t, "time RFC3339Nano", "?time=2000-01-01T00:00:00.000000000Z",
+		testOpts{Time: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)})
+	checkParsingHappyPath(t, "time RFC3339", "?time=2000-01-01T00:00:00Z",
+		testOpts{Time: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)})
+	checkParsingHappyPath(t, "time DateTime", "?time=2000-01-01%2000:00:00",
+		testOpts{Time: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)})
+	checkParsingHappyPath(t, "time Date", "?time=2000-01-01",
+		testOpts{Time: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)})
+	checkParsingHappyPath(t, "time Unix", "?time=946684800",
+		testOpts{Time: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)})
+
+	// pointer time
+	checkParsingHappyPath(t, "pointer time RFC3339Nano", "?pointer_time=2000-01-01T00:00:00.000000000Z",
+		testOpts{PointerTime: new(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC))})
+	checkParsingHappyPath(t, "pointer time RFC3339", "?pointer_time=2000-01-01T00:00:00Z",
+		testOpts{PointerTime: new(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC))})
+	checkParsingHappyPath(t, "pointer time DateTime", "?pointer_time=2000-01-01%2000:00:00",
+		testOpts{PointerTime: new(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC))})
+	checkParsingHappyPath(t, "pointer time Date", "?pointer_time=2000-01-01",
+		testOpts{PointerTime: new(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC))})
+	checkParsingHappyPath(t, "pointer time Unix", "?pointer_time=946684800",
+		testOpts{PointerTime: new(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC))})
+
+	// time slice
+	checkParsingHappyPath(t, "slice time (all formats)", "?time_slice=2000-01-01T00:00:00.000000000Z&time_slice=2001-01-01T00:00:00Z&time_slice=2002-01-01%2000:00:00&time_slice=2003-01-01&time_slice=1072915200",
+		testOpts{TimeSlice: []time.Time{
+			time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC),
+			time.Date(2001, 1, 1, 0, 0, 0, 0, time.UTC),
+			time.Date(2002, 1, 1, 0, 0, 0, 0, time.UTC),
+			time.Date(2003, 1, 1, 0, 0, 0, 0, time.UTC),
+			time.Date(2004, 1, 1, 0, 0, 0, 0, time.UTC),
+		}})
+	checkParsingHappyPath(t, "slice time (all formats, comma-separated)", "?time_slice=2000-01-01T00:00:00.000000000Z,2001-01-01T00:00:00Z,2002-01-01%2000:00:00,2003-01-01,1072915200",
+		testOpts{TimeSlice: []time.Time{
+			time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC),
+			time.Date(2001, 1, 1, 0, 0, 0, 0, time.UTC),
+			time.Date(2002, 1, 1, 0, 0, 0, 0, time.UTC),
+			time.Date(2003, 1, 1, 0, 0, 0, 0, time.UTC),
+			time.Date(2004, 1, 1, 0, 0, 0, 0, time.UTC),
+		}})
+
+	// option time
+	checkParsingHappyPath(t, "option time RFC3339Nano", "?option_time=2000-01-01T00:00:00.000000000Z",
+		testOpts{OptionTime: Some(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC))})
+	checkParsingHappyPath(t, "option time RFC3339", "?option_time=2000-01-01T00:00:00Z",
+		testOpts{OptionTime: Some(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC))})
+	checkParsingHappyPath(t, "option time DateTime", "?option_time=2000-01-01%2000:00:00",
+		testOpts{OptionTime: Some(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC))})
+	checkParsingHappyPath(t, "option time Date", "?option_time=2000-01-01",
+		testOpts{OptionTime: Some(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC))})
+	checkParsingHappyPath(t, "option time Unix", "?option_time=946684800",
+		testOpts{OptionTime: Some(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC))})
+
+	// plain scalars
+	checkParsingHappyPath(t, "bool", "?bool=true", testOpts{Bool: true})
+	checkParsingHappyPath(t, "string", "?string=hello", testOpts{String: "hello"})
+	checkParsingHappyPath(t, "int", "?int=42", testOpts{Int: 42})
+	checkParsingHappyPath(t, "int8", "?int8=8", testOpts{Int8: 8})
+	checkParsingHappyPath(t, "int16", "?int16=16", testOpts{Int16: 16})
+	checkParsingHappyPath(t, "int32", "?int32=32", testOpts{Int32: 32})
+	checkParsingHappyPath(t, "int64", "?int64=64", testOpts{Int64: 64})
+	checkParsingHappyPath(t, "uint", "?uint=42", testOpts{Uint: 42})
+	checkParsingHappyPath(t, "uint8", "?uint8=8", testOpts{Uint8: 8})
+	checkParsingHappyPath(t, "uint16", "?uint16=16", testOpts{Uint16: 16})
+	checkParsingHappyPath(t, "uint32", "?uint32=32", testOpts{Uint32: 32})
+	checkParsingHappyPath(t, "uint64", "?uint64=64", testOpts{Uint64: 64})
+	checkParsingHappyPath(t, "float32", "?float32=1.5", testOpts{Float32: 1.5})
+	checkParsingHappyPath(t, "float64", "?float64=2.5", testOpts{Float64: 2.5})
+
+	// pointer scalars
+	checkParsingHappyPath(t, "pointer_struct", "?pointer_struct.name=bar&pointer_struct.age=7",
+		testOpts{PointerStruct: &testInnerOpts{Name: "bar", Age: 7}})
+	checkParsingHappyPath(t, "pointer_bool", "?pointer_bool=true", testOpts{PointerBool: new(true)})
+	checkParsingHappyPath(t, "pointer_string", "?pointer_string=world", testOpts{PointerString: new("world")})
+	checkParsingHappyPath(t, "pointer_int", "?pointer_int=7", testOpts{PointerInt: new(7)})
+	checkParsingHappyPath(t, "pointer_int8", "?pointer_int8=8", testOpts{PointerInt8: new(int8(8))})
+	checkParsingHappyPath(t, "pointer_int16", "?pointer_int16=16", testOpts{PointerInt16: new(int16(16))})
+	checkParsingHappyPath(t, "pointer_int32", "?pointer_int32=32", testOpts{PointerInt32: new(int32(32))})
+	checkParsingHappyPath(t, "pointer_int64", "?pointer_int64=64", testOpts{PointerInt64: new(int64(64))})
+	checkParsingHappyPath(t, "pointer_uint", "?pointer_uint=7", testOpts{PointerUint: new(uint(7))})
+	checkParsingHappyPath(t, "pointer_uint8", "?pointer_uint8=8", testOpts{PointerUint8: new(uint8(8))})
+	checkParsingHappyPath(t, "pointer_uint16", "?pointer_uint16=16", testOpts{PointerUint16: new(uint16(16))})
+	checkParsingHappyPath(t, "pointer_uint32", "?pointer_uint32=32", testOpts{PointerUint32: new(uint32(32))})
+	checkParsingHappyPath(t, "pointer_uint64", "?pointer_uint64=64", testOpts{PointerUint64: new(uint64(64))})
+	checkParsingHappyPath(t, "pointer_float32", "?pointer_float32=3.14", testOpts{PointerFloat32: new(float32(3.14))})
+	checkParsingHappyPath(t, "pointer_float64", "?pointer_float64=2.718", testOpts{PointerFloat64: new(2.718)})
+
+	// slices (repeated keys)
+	checkParsingHappyPath(t, "bool_slice repeated", "?bool_slice=true&bool_slice=false&bool_slice=true",
+		testOpts{BoolSlice: []bool{true, false, true}})
+	checkParsingHappyPath(t, "string_slice repeated", "?string_slice=a&string_slice=b&string_slice=c",
+		testOpts{StringSlice: []string{"a", "b", "c"}})
+	checkParsingHappyPath(t, "int_slice repeated", "?int_slice=1&int_slice=2&int_slice=3",
+		testOpts{IntSlice: []int{1, 2, 3}})
+	checkParsingHappyPath(t, "int8_slice repeated", "?int8_slice=1&int8_slice=2&int8_slice=3",
+		testOpts{Int8Slice: []int8{1, 2, 3}})
+	checkParsingHappyPath(t, "int16_slice repeated", "?int16_slice=1&int16_slice=2&int16_slice=3",
+		testOpts{Int16Slice: []int16{1, 2, 3}})
+	checkParsingHappyPath(t, "int32_slice repeated", "?int32_slice=1&int32_slice=2&int32_slice=3",
+		testOpts{Int32Slice: []int32{1, 2, 3}})
+	checkParsingHappyPath(t, "int64_slice repeated", "?int64_slice=1&int64_slice=2&int64_slice=3",
+		testOpts{Int64Slice: []int64{1, 2, 3}})
+	checkParsingHappyPath(t, "uint_slice repeated", "?uint_slice=1&uint_slice=2&uint_slice=3",
+		testOpts{UintSlice: []uint{1, 2, 3}})
+	checkParsingHappyPath(t, "uint8_slice repeated", "?uint8_slice=1&uint8_slice=2&uint8_slice=3",
+		testOpts{Uint8Slice: []uint8{1, 2, 3}})
+	checkParsingHappyPath(t, "uint16_slice repeated", "?uint16_slice=1&uint16_slice=2&uint16_slice=3",
+		testOpts{Uint16Slice: []uint16{1, 2, 3}})
+	checkParsingHappyPath(t, "uint32_slice repeated", "?uint32_slice=1&uint32_slice=2&uint32_slice=3",
+		testOpts{Uint32Slice: []uint32{1, 2, 3}})
+	checkParsingHappyPath(t, "uint64_slice repeated", "?uint64_slice=1&uint64_slice=2&uint64_slice=3",
+		testOpts{Uint64Slice: []uint64{1, 2, 3}})
+	checkParsingHappyPath(t, "float32_slice repeated", "?float32_slice=1.5&float32_slice=2.5",
+		testOpts{Float32Slice: []float32{1.5, 2.5}})
+	checkParsingHappyPath(t, "float64_slice repeated", "?float64_slice=1.5&float64_slice=2.5",
+		testOpts{Float64Slice: []float64{1.5, 2.5}})
+
+	// slices (comma-separated)
+	checkParsingHappyPath(t, "bool_slice comma", "?bool_slice=true,false,true",
+		testOpts{BoolSlice: []bool{true, false, true}})
+	checkParsingHappyPath(t, "string_slice comma", "?string_slice=a,b,c",
+		testOpts{StringSlice: []string{"a", "b", "c"}})
+	checkParsingHappyPath(t, "int_slice comma", "?int_slice=1,2,3",
+		testOpts{IntSlice: []int{1, 2, 3}})
+	checkParsingHappyPath(t, "int8_slice comma", "?int8_slice=1,2,3",
+		testOpts{Int8Slice: []int8{1, 2, 3}})
+	checkParsingHappyPath(t, "int16_slice comma", "?int16_slice=1,2,3",
+		testOpts{Int16Slice: []int16{1, 2, 3}})
+	checkParsingHappyPath(t, "int32_slice comma", "?int32_slice=1,2,3",
+		testOpts{Int32Slice: []int32{1, 2, 3}})
+	checkParsingHappyPath(t, "int64_slice comma", "?int64_slice=1,2,3",
+		testOpts{Int64Slice: []int64{1, 2, 3}})
+	checkParsingHappyPath(t, "uint_slice comma", "?uint_slice=1,2,3",
+		testOpts{UintSlice: []uint{1, 2, 3}})
+	checkParsingHappyPath(t, "uint8_slice comma", "?uint8_slice=1,2,3",
+		testOpts{Uint8Slice: []uint8{1, 2, 3}})
+	checkParsingHappyPath(t, "uint16_slice comma", "?uint16_slice=1,2,3",
+		testOpts{Uint16Slice: []uint16{1, 2, 3}})
+	checkParsingHappyPath(t, "uint32_slice comma", "?uint32_slice=1,2,3",
+		testOpts{Uint32Slice: []uint32{1, 2, 3}})
+	checkParsingHappyPath(t, "uint64_slice comma", "?uint64_slice=1,2,3",
+		testOpts{Uint64Slice: []uint64{1, 2, 3}})
+	checkParsingHappyPath(t, "float32_slice comma", "?float32_slice=1.5,2.5",
+		testOpts{Float32Slice: []float32{1.5, 2.5}})
+	checkParsingHappyPath(t, "float64_slice comma", "?float64_slice=1.5,2.5",
+		testOpts{Float64Slice: []float64{1.5, 2.5}})
+
+	// Option scalars
+	checkParsingHappyPath(t, "option_bool", "?option_bool=true", testOpts{OptionBool: Some(true)})
+	checkParsingHappyPath(t, "option_string", "?option_string=hello", testOpts{OptionString: Some("hello")})
+	checkParsingHappyPath(t, "option_int", "?option_int=42", testOpts{OptionInt: Some(42)})
+	checkParsingHappyPath(t, "option_int8", "?option_int8=8", testOpts{OptionInt8: Some(int8(8))})
+	checkParsingHappyPath(t, "option_int16", "?option_int16=16", testOpts{OptionInt16: Some(int16(16))})
+	checkParsingHappyPath(t, "option_int32", "?option_int32=32", testOpts{OptionInt32: Some(int32(32))})
+	checkParsingHappyPath(t, "option_int64", "?option_int64=64", testOpts{OptionInt64: Some(int64(64))})
+	checkParsingHappyPath(t, "option_uint", "?option_uint=42", testOpts{OptionUint: Some(uint(42))})
+	checkParsingHappyPath(t, "option_uint8", "?option_uint8=8", testOpts{OptionUint8: Some(uint8(8))})
+	checkParsingHappyPath(t, "option_uint16", "?option_uint16=16", testOpts{OptionUint16: Some(uint16(16))})
+	checkParsingHappyPath(t, "option_uint32", "?option_uint32=32", testOpts{OptionUint32: Some(uint32(32))})
+	checkParsingHappyPath(t, "option_uint64", "?option_uint64=64", testOpts{OptionUint64: Some(uint64(64))})
+	checkParsingHappyPath(t, "option_float32", "?option_float32=1.5", testOpts{OptionFloat32: Some(float32(1.5))})
+	checkParsingHappyPath(t, "option_float64", "?option_float64=2.5", testOpts{OptionFloat64: Some(2.5)})
+
+	// multiple fields at once
+	checkParsingHappyPath(t, "multiple fields", "?bool=true&string=hi&int=5&option_string=world",
+		testOpts{Bool: true, String: "hi", Int: 5, OptionString: Some("world")})
+}
+
+func checkParsingPanic(t *testing.T, panicMsg string, fn func()) {
+	t.Helper()
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Errorf("expected panic %q, but function did not panic", panicMsg)
+		}
+		got, ok := r.(string)
+		if !ok {
+			t.Errorf("expected panic with string %q, but got non-string panic: %v", panicMsg, r)
+		}
+		if got != panicMsg {
+			t.Errorf("expected panic: %s, but got: %s", panicMsg, got)
+		}
+	}()
+	fn()
+}
+
+func checkParsingError(t *testing.T, query, errMsg string) {
+	t.Helper()
+	var to testOpts
+	r := httptest.NewRequest(http.MethodGet, "/some/unimportant/path"+query, http.NoBody)
+	resultingError := opts.ParseQueryString(r, &to)
+	th.AssertErr(t, errMsg, resultingError)
+}
+
+func TestOptParserErrors(t *testing.T) {
+	// non-pointer or non-struct input (these panic)
+	r := httptest.NewRequest(http.MethodGet, "/some/unimportant/path", http.NoBody)
+	checkParsingPanic(t, "expected opts to be a non-nil pointer", func() {
+		opts.ParseQueryString(r, nil) //nolint:errcheck // won't get to this part
+	})
+	checkParsingPanic(t, "expected opts to be a non-nil pointer", func() {
+		opts.ParseQueryString(r, testOpts{}) //nolint:errcheck // won't get to this part
+	})
+	checkParsingPanic(t, "expected opts to point to a struct", func() {
+		opts.ParseQueryString(r, new(5)) //nolint:errcheck // won't get to this part
+	})
+
+	// incompatible struct (panics)
+	type testNonOpts struct {
+		String string `yaml:"string"`
+	}
+	checkParsingPanic(t, `expected "String" to have a "q:"-tag`, func() {
+		opts.ParseQueryString(r, &testNonOpts{}) //nolint:errcheck // won't get to this part
+	})
+
+	// missing required parameter
+	type testStringRequiredOpts struct {
+		String string `q:"string" required:"true"`
+	}
+	resultingError := opts.ParseQueryString(r, &testStringRequiredOpts{})
+	th.AssertErr(t, `missing value for query parameter "string"`, resultingError)
+	type testStringSliceRequiredOpts struct {
+		StringSlice []string `q:"string_slice" required:"true"`
+	}
+	resultingError = opts.ParseQueryString(r, &testStringSliceRequiredOpts{})
+	th.AssertErr(t, `missing value for query parameter "string_slice"`, resultingError)
+
+	// unknown parameter
+	checkParsingError(t, "?someRandomParam=foo", `unknown query parameter "someRandomParam"`)
+
+	// wrong type: map
+	checkParsingError(t, "?string_map=foo", `invalid value for query parameter "string_map": invalid map entry "foo": expected key:value`)
+
+	// wrong type: time
+	checkParsingError(t, "?time=foo", `invalid value for query parameter "time": cannot parse "foo" as time; accepted: DateOnly, DateTime, RFC3339, RFC3339Nano, Unix`)
+	checkParsingError(t, "?pointer_time=foo", `invalid value for query parameter "pointer_time": cannot parse "foo" as time; accepted: DateOnly, DateTime, RFC3339, RFC3339Nano, Unix`)
+	checkParsingError(t, "?time_slice=foo", `invalid value for query parameter "time_slice": element 0: cannot parse "foo" as time; accepted: DateOnly, DateTime, RFC3339, RFC3339Nano, Unix`)
+	checkParsingError(t, "?option_time=foo", `invalid value for query parameter "option_time": cannot parse "foo" as time; accepted: DateOnly, DateTime, RFC3339, RFC3339Nano, Unix`)
+
+	// multiple values: time
+	checkParsingError(t, "?time=2000-01-01&time=2001-01-01", `invalid value for query parameter "time": expected a single value, got 2`)
+	checkParsingError(t, "?pointer_time=2000-01-01&pointer_time=2001-01-01", `invalid value for query parameter "pointer_time": expected a single value, got 2`)
+	checkParsingError(t, "?option_time=2000-01-01&option_time=2001-01-01", `invalid value for query parameter "option_time": expected a single value, got 2`)
+
+	// wrong type: bool
+	checkParsingError(t, "?bool=foo", `invalid value for query parameter "bool": strconv.ParseBool: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?pointer_bool=foo", `invalid value for query parameter "pointer_bool": strconv.ParseBool: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?option_bool=foo", `invalid value for query parameter "option_bool": strconv.ParseBool: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?bool_slice=foo", `invalid value for query parameter "bool_slice": element 0: strconv.ParseBool: parsing "foo": invalid syntax`)
+
+	// wrong format: slices
+	r = httptest.NewRequest(http.MethodGet, "/some/unimportant/path?string_slice=a&string_slice=b", http.NoBody)
+	type testSliceFormatOpts struct {
+		StringSlice []string `q:"string_slice" format:"comma-separated"`
+	}
+	resultingError = opts.ParseQueryString(r, &testSliceFormatOpts{})
+	th.AssertErr(t, `query parameter "string_slice" uses comma-separated format, but was provided as repeated keys`, resultingError)
+	r = httptest.NewRequest(http.MethodGet, "/some/unimportant/path?string_slice=a,b,c,d&string_slice=e", http.NoBody)
+	resultingError = opts.ParseQueryString(r, &testSliceFormatOpts{})
+	th.AssertErr(t, `query parameter "string_slice" uses comma-separated format, but was provided as repeated keys`, resultingError)
+
+	// wrong format: time
+	r = httptest.NewRequest(http.MethodGet, "/some/unimportant/path?time=2000-01-01%2000:00", http.NoBody)
+	type testImpossibleTimeFormatOpts struct {
+		Time time.Time `q:"time" format:"foo"`
+	}
+	resultingError = opts.ParseQueryString(r, &testImpossibleTimeFormatOpts{})
+	th.AssertErr(t, `unsupported time format "foo"; accepted: DateOnly, DateTime, RFC3339, RFC3339Nano, Unix`, resultingError)
+	type testTimeFormatOpts struct {
+		Time time.Time `q:"time" format:"RFC3339"`
+	}
+	resultingError = opts.ParseQueryString(r, &testTimeFormatOpts{})
+	th.AssertErr(t, `invalid value for query parameter "time": cannot parse "2000-01-01 00:00" as RFC3339: parsing time "2000-01-01 00:00" as "2006-01-02T15:04:05Z07:00": cannot parse " 00:00" as "T"`, resultingError)
+
+	// wrong type: numbers
+	checkParsingError(t, "?int=foo", `invalid value for query parameter "int": strconv.ParseInt: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?int8=foo", `invalid value for query parameter "int8": strconv.ParseInt: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?int16=foo", `invalid value for query parameter "int16": strconv.ParseInt: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?int32=foo", `invalid value for query parameter "int32": strconv.ParseInt: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?int64=foo", `invalid value for query parameter "int64": strconv.ParseInt: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?uint=foo", `invalid value for query parameter "uint": strconv.ParseUint: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?uint8=foo", `invalid value for query parameter "uint8": strconv.ParseUint: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?uint16=foo", `invalid value for query parameter "uint16": strconv.ParseUint: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?uint32=foo", `invalid value for query parameter "uint32": strconv.ParseUint: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?uint64=foo", `invalid value for query parameter "uint64": strconv.ParseUint: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?float32=foo", `invalid value for query parameter "float32": strconv.ParseFloat: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?float64=foo", `invalid value for query parameter "float64": strconv.ParseFloat: parsing "foo": invalid syntax`)
+
+	// wrong type: pointer of numbers
+	checkParsingError(t, "?pointer_int=foo", `invalid value for query parameter "pointer_int": strconv.ParseInt: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?pointer_int8=foo", `invalid value for query parameter "pointer_int8": strconv.ParseInt: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?pointer_int16=foo", `invalid value for query parameter "pointer_int16": strconv.ParseInt: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?pointer_int32=foo", `invalid value for query parameter "pointer_int32": strconv.ParseInt: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?pointer_int64=foo", `invalid value for query parameter "pointer_int64": strconv.ParseInt: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?pointer_uint=foo", `invalid value for query parameter "pointer_uint": strconv.ParseUint: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?pointer_uint8=foo", `invalid value for query parameter "pointer_uint8": strconv.ParseUint: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?pointer_uint16=foo", `invalid value for query parameter "pointer_uint16": strconv.ParseUint: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?pointer_uint32=foo", `invalid value for query parameter "pointer_uint32": strconv.ParseUint: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?pointer_uint64=foo", `invalid value for query parameter "pointer_uint64": strconv.ParseUint: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?pointer_float32=foo", `invalid value for query parameter "pointer_float32": strconv.ParseFloat: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?pointer_float64=foo", `invalid value for query parameter "pointer_float64": strconv.ParseFloat: parsing "foo": invalid syntax`)
+
+	// wrong type: slice of numbers
+	checkParsingError(t, "?int_slice=foo", `invalid value for query parameter "int_slice": element 0: strconv.ParseInt: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?int8_slice=foo", `invalid value for query parameter "int8_slice": element 0: strconv.ParseInt: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?int16_slice=foo", `invalid value for query parameter "int16_slice": element 0: strconv.ParseInt: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?int32_slice=foo", `invalid value for query parameter "int32_slice": element 0: strconv.ParseInt: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?int64_slice=foo", `invalid value for query parameter "int64_slice": element 0: strconv.ParseInt: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?uint_slice=foo", `invalid value for query parameter "uint_slice": element 0: strconv.ParseUint: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?uint8_slice=foo", `invalid value for query parameter "uint8_slice": element 0: strconv.ParseUint: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?uint16_slice=foo", `invalid value for query parameter "uint16_slice": element 0: strconv.ParseUint: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?uint32_slice=foo", `invalid value for query parameter "uint32_slice": element 0: strconv.ParseUint: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?uint64_slice=foo", `invalid value for query parameter "uint64_slice": element 0: strconv.ParseUint: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?float32_slice=foo", `invalid value for query parameter "float32_slice": element 0: strconv.ParseFloat: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?float64_slice=foo", `invalid value for query parameter "float64_slice": element 0: strconv.ParseFloat: parsing "foo": invalid syntax`)
+
+	// wrong type: Option of numbers
+	checkParsingError(t, "?option_int=foo", `invalid value for query parameter "option_int": strconv.ParseInt: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?option_int8=foo", `invalid value for query parameter "option_int8": strconv.ParseInt: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?option_int16=foo", `invalid value for query parameter "option_int16": strconv.ParseInt: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?option_int32=foo", `invalid value for query parameter "option_int32": strconv.ParseInt: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?option_int64=foo", `invalid value for query parameter "option_int64": strconv.ParseInt: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?option_uint=foo", `invalid value for query parameter "option_uint": strconv.ParseUint: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?option_uint8=foo", `invalid value for query parameter "option_uint8": strconv.ParseUint: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?option_uint16=foo", `invalid value for query parameter "option_uint16": strconv.ParseUint: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?option_uint32=foo", `invalid value for query parameter "option_uint32": strconv.ParseUint: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?option_uint64=foo", `invalid value for query parameter "option_uint64": strconv.ParseUint: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?option_float32=foo", `invalid value for query parameter "option_float32": strconv.ParseFloat: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?option_float64=foo", `invalid value for query parameter "option_float64": strconv.ParseFloat: parsing "foo": invalid syntax`)
+
+	// multiple values: scalar
+	checkParsingError(t, "?bool=true&bool=false", `invalid value for query parameter "bool": expected a single value, got 2`)
+	checkParsingError(t, "?string=foo&string=bar", `invalid value for query parameter "string": expected a single value, got 2`)
+	checkParsingError(t, "?int=foo&int=bar", `invalid value for query parameter "int": expected a single value, got 2`)
+	checkParsingError(t, "?int8=foo&int8=bar", `invalid value for query parameter "int8": expected a single value, got 2`)
+	checkParsingError(t, "?int16=foo&int16=bar", `invalid value for query parameter "int16": expected a single value, got 2`)
+	checkParsingError(t, "?int32=foo&int32=bar", `invalid value for query parameter "int32": expected a single value, got 2`)
+	checkParsingError(t, "?int64=foo&int64=bar", `invalid value for query parameter "int64": expected a single value, got 2`)
+	checkParsingError(t, "?uint=foo&uint=bar", `invalid value for query parameter "uint": expected a single value, got 2`)
+	checkParsingError(t, "?uint8=foo&uint8=bar", `invalid value for query parameter "uint8": expected a single value, got 2`)
+	checkParsingError(t, "?uint16=foo&uint16=bar", `invalid value for query parameter "uint16": expected a single value, got 2`)
+	checkParsingError(t, "?uint32=foo&uint32=bar", `invalid value for query parameter "uint32": expected a single value, got 2`)
+	checkParsingError(t, "?uint64=foo&uint64=bar", `invalid value for query parameter "uint64": expected a single value, got 2`)
+	checkParsingError(t, "?float32=foo&float32=bar", `invalid value for query parameter "float32": expected a single value, got 2`)
+	checkParsingError(t, "?float64=foo&float64=bar", `invalid value for query parameter "float64": expected a single value, got 2`)
+
+	// multiple vales: pointer of scalar
+	checkParsingError(t, "?pointer_bool=true&pointer_bool=false", `invalid value for query parameter "pointer_bool": expected a single value, got 2`)
+	checkParsingError(t, "?pointer_string=foo&pointer_string=bar", `invalid value for query parameter "pointer_string": expected a single value, got 2`)
+	checkParsingError(t, "?pointer_int=foo&pointer_int=bar", `invalid value for query parameter "pointer_int": expected a single value, got 2`)
+	checkParsingError(t, "?pointer_int8=foo&pointer_int8=bar", `invalid value for query parameter "pointer_int8": expected a single value, got 2`)
+	checkParsingError(t, "?pointer_int16=foo&pointer_int16=bar", `invalid value for query parameter "pointer_int16": expected a single value, got 2`)
+	checkParsingError(t, "?pointer_int32=foo&pointer_int32=bar", `invalid value for query parameter "pointer_int32": expected a single value, got 2`)
+	checkParsingError(t, "?pointer_int64=foo&pointer_int64=bar", `invalid value for query parameter "pointer_int64": expected a single value, got 2`)
+	checkParsingError(t, "?pointer_uint=foo&pointer_uint=bar", `invalid value for query parameter "pointer_uint": expected a single value, got 2`)
+	checkParsingError(t, "?pointer_uint8=foo&pointer_uint8=bar", `invalid value for query parameter "pointer_uint8": expected a single value, got 2`)
+	checkParsingError(t, "?pointer_uint16=foo&pointer_uint16=bar", `invalid value for query parameter "pointer_uint16": expected a single value, got 2`)
+	checkParsingError(t, "?pointer_uint32=foo&pointer_uint32=bar", `invalid value for query parameter "pointer_uint32": expected a single value, got 2`)
+	checkParsingError(t, "?pointer_uint64=foo&pointer_uint64=bar", `invalid value for query parameter "pointer_uint64": expected a single value, got 2`)
+	checkParsingError(t, "?pointer_float32=foo&pointer_float32=bar", `invalid value for query parameter "pointer_float32": expected a single value, got 2`)
+	checkParsingError(t, "?pointer_float64=foo&pointer_float64=bar", `invalid value for query parameter "pointer_float64": expected a single value, got 2`)
+
+	// multiple values: Option of scalar
+	checkParsingError(t, "?option_bool=true&option_bool=false", `invalid value for query parameter "option_bool": expected a single value, got 2`)
+	checkParsingError(t, "?option_string=foo&option_string=bar", `invalid value for query parameter "option_string": expected a single value, got 2`)
+	checkParsingError(t, "?option_int=foo&option_int=bar", `invalid value for query parameter "option_int": expected a single value, got 2`)
+	checkParsingError(t, "?option_int8=foo&option_int8=bar", `invalid value for query parameter "option_int8": expected a single value, got 2`)
+	checkParsingError(t, "?option_int16=foo&option_int16=bar", `invalid value for query parameter "option_int16": expected a single value, got 2`)
+	checkParsingError(t, "?option_int32=foo&option_int32=bar", `invalid value for query parameter "option_int32": expected a single value, got 2`)
+	checkParsingError(t, "?option_int64=foo&option_int64=bar", `invalid value for query parameter "option_int64": expected a single value, got 2`)
+	checkParsingError(t, "?option_uint=foo&option_uint=bar", `invalid value for query parameter "option_uint": expected a single value, got 2`)
+	checkParsingError(t, "?option_uint8=foo&option_uint8=bar", `invalid value for query parameter "option_uint8": expected a single value, got 2`)
+	checkParsingError(t, "?option_uint16=foo&option_uint16=bar", `invalid value for query parameter "option_uint16": expected a single value, got 2`)
+	checkParsingError(t, "?option_uint32=foo&option_uint32=bar", `invalid value for query parameter "option_uint32": expected a single value, got 2`)
+	checkParsingError(t, "?option_uint64=foo&option_uint64=bar", `invalid value for query parameter "option_uint64": expected a single value, got 2`)
+	checkParsingError(t, "?option_float32=foo&option_float32=bar", `invalid value for query parameter "option_float32": expected a single value, got 2`)
+	checkParsingError(t, "?option_float64=foo&option_float64=bar", `invalid value for query parameter "option_float64": expected a single value, got 2`)
+
+	// int overflows
+	maxIntPlus1 := uint64(math.MaxInt) + 1
+	checkParsingError(t, "?int="+strconv.FormatUint(maxIntPlus1, 10), fmt.Sprintf(`invalid value for query parameter "int": strconv.ParseInt: parsing "%d": value out of range`, maxIntPlus1))
+	maxInt8Plus1 := uint64(math.MaxInt8) + 1
+	checkParsingError(t, "?int8="+strconv.FormatUint(maxInt8Plus1, 10), fmt.Sprintf(`invalid value for query parameter "int8": strconv.ParseInt: parsing "%d": value out of range`, maxInt8Plus1))
+	maxInt16Plus1 := uint64(math.MaxInt16) + 1
+	checkParsingError(t, "?int16="+strconv.FormatUint(maxInt16Plus1, 10), fmt.Sprintf(`invalid value for query parameter "int16": strconv.ParseInt: parsing "%d": value out of range`, maxInt16Plus1))
+	maxInt32Plus1 := uint64(math.MaxInt32) + 1
+	checkParsingError(t, "?int32="+strconv.FormatUint(maxInt32Plus1, 10), fmt.Sprintf(`invalid value for query parameter "int32": strconv.ParseInt: parsing "%d": value out of range`, maxInt32Plus1))
+	maxInt64Plus1 := uint64(math.MaxInt64) + 1
+	checkParsingError(t, "?int64="+strconv.FormatUint(maxInt64Plus1, 10), fmt.Sprintf(`invalid value for query parameter "int64": strconv.ParseInt: parsing "%d": value out of range`, maxInt64Plus1))
+
+	// int underflows
+	minIntMinus1 := "-" + strconv.FormatUint(uint64(math.MaxInt)+2, 10)
+	checkParsingError(t, "?int="+minIntMinus1, fmt.Sprintf(`invalid value for query parameter "int": strconv.ParseInt: parsing "%s": value out of range`, minIntMinus1))
+	minInt8Minus1 := strconv.FormatInt(int64(math.MinInt8)-1, 10)
+	checkParsingError(t, "?int8="+minInt8Minus1, fmt.Sprintf(`invalid value for query parameter "int8": strconv.ParseInt: parsing "%s": value out of range`, minInt8Minus1))
+	minInt16Minus1 := strconv.FormatInt(int64(math.MinInt16)-1, 10)
+	checkParsingError(t, "?int16="+minInt16Minus1, fmt.Sprintf(`invalid value for query parameter "int16": strconv.ParseInt: parsing "%s": value out of range`, minInt16Minus1))
+	minInt32Minus1 := strconv.FormatInt(int64(math.MinInt32)-1, 10)
+	checkParsingError(t, "?int32="+minInt32Minus1, fmt.Sprintf(`invalid value for query parameter "int32": strconv.ParseInt: parsing "%s": value out of range`, minInt32Minus1))
+	minInt64Minus1 := "-" + strconv.FormatUint(uint64(math.MaxInt64)+2, 10)
+	checkParsingError(t, "?int64="+minInt64Minus1, fmt.Sprintf(`invalid value for query parameter "int64": strconv.ParseInt: parsing "%s": value out of range`, minInt64Minus1))
+
+	// uint overflows
+	maxUintPlus1 := "18446744073709551616" // math.MaxUint64 + 1, cannot be represented in uint64
+	checkParsingError(t, "?uint="+maxUintPlus1, fmt.Sprintf(`invalid value for query parameter "uint": strconv.ParseUint: parsing "%s": value out of range`, maxUintPlus1))
+	maxUint8Plus1 := strconv.FormatUint(uint64(math.MaxUint8)+1, 10)
+	checkParsingError(t, "?uint8="+maxUint8Plus1, fmt.Sprintf(`invalid value for query parameter "uint8": strconv.ParseUint: parsing "%s": value out of range`, maxUint8Plus1))
+	maxUint16Plus1 := strconv.FormatUint(uint64(math.MaxUint16)+1, 10)
+	checkParsingError(t, "?uint16="+maxUint16Plus1, fmt.Sprintf(`invalid value for query parameter "uint16": strconv.ParseUint: parsing "%s": value out of range`, maxUint16Plus1))
+	maxUint32Plus1 := strconv.FormatUint(uint64(math.MaxUint32)+1, 10)
+	checkParsingError(t, "?uint32="+maxUint32Plus1, fmt.Sprintf(`invalid value for query parameter "uint32": strconv.ParseUint: parsing "%s": value out of range`, maxUint32Plus1))
+	checkParsingError(t, "?uint64="+maxUintPlus1, fmt.Sprintf(`invalid value for query parameter "uint64": strconv.ParseUint: parsing "%s": value out of range`, maxUintPlus1))
+
+	// uint underflows (negative values rejected)
+	checkParsingError(t, "?uint=-1", `invalid value for query parameter "uint": strconv.ParseUint: parsing "-1": invalid syntax`)
+	checkParsingError(t, "?uint8=-1", `invalid value for query parameter "uint8": strconv.ParseUint: parsing "-1": invalid syntax`)
+	checkParsingError(t, "?uint16=-1", `invalid value for query parameter "uint16": strconv.ParseUint: parsing "-1": invalid syntax`)
+	checkParsingError(t, "?uint32=-1", `invalid value for query parameter "uint32": strconv.ParseUint: parsing "-1": invalid syntax`)
+	checkParsingError(t, "?uint64=-1", `invalid value for query parameter "uint64": strconv.ParseUint: parsing "-1": invalid syntax`)
+
+	// float overflows
+	overflowFloat32 := strconv.FormatFloat(math.MaxFloat32*2, 'g', -1, 64)
+	overflowFloat32Query := strings.ReplaceAll(overflowFloat32, "+", "%2B")
+	checkParsingError(t, "?float32="+overflowFloat32Query, fmt.Sprintf(`invalid value for query parameter "float32": strconv.ParseFloat: parsing "%s": value out of range`, overflowFloat32))
+	overflowFloat64 := "1.8e+309"
+	overflowFloat64Query := strings.ReplaceAll(overflowFloat64, "+", "%2B")
+	checkParsingError(t, "?float64="+overflowFloat64Query, fmt.Sprintf(`invalid value for query parameter "float64": strconv.ParseFloat: parsing "%s": value out of range`, overflowFloat64))
+
+	// float underflows (negative overflow)
+	underflowFloat32 := strconv.FormatFloat(-math.MaxFloat32*2, 'g', -1, 64)
+	underflowFloat32Query := strings.ReplaceAll(underflowFloat32, "+", "%2B")
+	checkParsingError(t, "?float32="+underflowFloat32Query, fmt.Sprintf(`invalid value for query parameter "float32": strconv.ParseFloat: parsing "%s": value out of range`, underflowFloat32))
+	underflowFloat64 := "-1.8e+309"
+	underflowFloat64Query := strings.ReplaceAll(underflowFloat64, "+", "%2B")
+	checkParsingError(t, "?float64="+underflowFloat64Query, fmt.Sprintf(`invalid value for query parameter "float64": strconv.ParseFloat: parsing "%s": value out of range`, underflowFloat64))
+
+	// pointer int overflows
+	checkParsingError(t, "?pointer_int="+strconv.FormatUint(maxIntPlus1, 10), fmt.Sprintf(`invalid value for query parameter "pointer_int": strconv.ParseInt: parsing "%d": value out of range`, maxIntPlus1))
+	checkParsingError(t, "?pointer_int8="+strconv.FormatUint(maxInt8Plus1, 10), fmt.Sprintf(`invalid value for query parameter "pointer_int8": strconv.ParseInt: parsing "%d": value out of range`, maxInt8Plus1))
+	checkParsingError(t, "?pointer_int16="+strconv.FormatUint(maxInt16Plus1, 10), fmt.Sprintf(`invalid value for query parameter "pointer_int16": strconv.ParseInt: parsing "%d": value out of range`, maxInt16Plus1))
+	checkParsingError(t, "?pointer_int32="+strconv.FormatUint(maxInt32Plus1, 10), fmt.Sprintf(`invalid value for query parameter "pointer_int32": strconv.ParseInt: parsing "%d": value out of range`, maxInt32Plus1))
+	checkParsingError(t, "?pointer_int64="+strconv.FormatUint(maxInt64Plus1, 10), fmt.Sprintf(`invalid value for query parameter "pointer_int64": strconv.ParseInt: parsing "%d": value out of range`, maxInt64Plus1))
+
+	// pointer int underflows
+	checkParsingError(t, "?pointer_int="+minIntMinus1, fmt.Sprintf(`invalid value for query parameter "pointer_int": strconv.ParseInt: parsing "%s": value out of range`, minIntMinus1))
+	checkParsingError(t, "?pointer_int8="+minInt8Minus1, fmt.Sprintf(`invalid value for query parameter "pointer_int8": strconv.ParseInt: parsing "%s": value out of range`, minInt8Minus1))
+	checkParsingError(t, "?pointer_int16="+minInt16Minus1, fmt.Sprintf(`invalid value for query parameter "pointer_int16": strconv.ParseInt: parsing "%s": value out of range`, minInt16Minus1))
+	checkParsingError(t, "?pointer_int32="+minInt32Minus1, fmt.Sprintf(`invalid value for query parameter "pointer_int32": strconv.ParseInt: parsing "%s": value out of range`, minInt32Minus1))
+	checkParsingError(t, "?pointer_int64="+minInt64Minus1, fmt.Sprintf(`invalid value for query parameter "pointer_int64": strconv.ParseInt: parsing "%s": value out of range`, minInt64Minus1))
+
+	// pointer float overflows
+	checkParsingError(t, "?pointer_float32="+overflowFloat32Query, fmt.Sprintf(`invalid value for query parameter "pointer_float32": strconv.ParseFloat: parsing "%s": value out of range`, overflowFloat32))
+	checkParsingError(t, "?pointer_float64="+overflowFloat64Query, fmt.Sprintf(`invalid value for query parameter "pointer_float64": strconv.ParseFloat: parsing "%s": value out of range`, overflowFloat64))
+
+	// pointer float underflows (negative overflow)
+	checkParsingError(t, "?pointer_float32="+underflowFloat32Query, fmt.Sprintf(`invalid value for query parameter "pointer_float32": strconv.ParseFloat: parsing "%s": value out of range`, underflowFloat32))
+	checkParsingError(t, "?pointer_float64="+underflowFloat64Query, fmt.Sprintf(`invalid value for query parameter "pointer_float64": strconv.ParseFloat: parsing "%s": value out of range`, underflowFloat64))
+
+	// slice int overflows
+	checkParsingError(t, "?int_slice="+strconv.FormatUint(maxIntPlus1, 10), fmt.Sprintf(`invalid value for query parameter "int_slice": element 0: strconv.ParseInt: parsing "%d": value out of range`, maxIntPlus1))
+	checkParsingError(t, "?int8_slice="+strconv.FormatUint(maxInt8Plus1, 10), fmt.Sprintf(`invalid value for query parameter "int8_slice": element 0: strconv.ParseInt: parsing "%d": value out of range`, maxInt8Plus1))
+	checkParsingError(t, "?int16_slice="+strconv.FormatUint(maxInt16Plus1, 10), fmt.Sprintf(`invalid value for query parameter "int16_slice": element 0: strconv.ParseInt: parsing "%d": value out of range`, maxInt16Plus1))
+	checkParsingError(t, "?int32_slice="+strconv.FormatUint(maxInt32Plus1, 10), fmt.Sprintf(`invalid value for query parameter "int32_slice": element 0: strconv.ParseInt: parsing "%d": value out of range`, maxInt32Plus1))
+	checkParsingError(t, "?int64_slice="+strconv.FormatUint(maxInt64Plus1, 10), fmt.Sprintf(`invalid value for query parameter "int64_slice": element 0: strconv.ParseInt: parsing "%d": value out of range`, maxInt64Plus1))
+
+	// slice int underflows
+	checkParsingError(t, "?int_slice="+minIntMinus1, fmt.Sprintf(`invalid value for query parameter "int_slice": element 0: strconv.ParseInt: parsing "%s": value out of range`, minIntMinus1))
+	checkParsingError(t, "?int8_slice="+minInt8Minus1, fmt.Sprintf(`invalid value for query parameter "int8_slice": element 0: strconv.ParseInt: parsing "%s": value out of range`, minInt8Minus1))
+	checkParsingError(t, "?int16_slice="+minInt16Minus1, fmt.Sprintf(`invalid value for query parameter "int16_slice": element 0: strconv.ParseInt: parsing "%s": value out of range`, minInt16Minus1))
+	checkParsingError(t, "?int32_slice="+minInt32Minus1, fmt.Sprintf(`invalid value for query parameter "int32_slice": element 0: strconv.ParseInt: parsing "%s": value out of range`, minInt32Minus1))
+	checkParsingError(t, "?int64_slice="+minInt64Minus1, fmt.Sprintf(`invalid value for query parameter "int64_slice": element 0: strconv.ParseInt: parsing "%s": value out of range`, minInt64Minus1))
+
+	// slice uint overflows
+	checkParsingError(t, "?uint_slice="+maxUintPlus1, fmt.Sprintf(`invalid value for query parameter "uint_slice": element 0: strconv.ParseUint: parsing "%s": value out of range`, maxUintPlus1))
+	checkParsingError(t, "?uint8_slice="+maxUint8Plus1, fmt.Sprintf(`invalid value for query parameter "uint8_slice": element 0: strconv.ParseUint: parsing "%s": value out of range`, maxUint8Plus1))
+	checkParsingError(t, "?uint16_slice="+maxUint16Plus1, fmt.Sprintf(`invalid value for query parameter "uint16_slice": element 0: strconv.ParseUint: parsing "%s": value out of range`, maxUint16Plus1))
+	checkParsingError(t, "?uint32_slice="+maxUint32Plus1, fmt.Sprintf(`invalid value for query parameter "uint32_slice": element 0: strconv.ParseUint: parsing "%s": value out of range`, maxUint32Plus1))
+	checkParsingError(t, "?uint64_slice="+maxUintPlus1, fmt.Sprintf(`invalid value for query parameter "uint64_slice": element 0: strconv.ParseUint: parsing "%s": value out of range`, maxUintPlus1))
+
+	// slice uint underflows (negative values rejected)
+	checkParsingError(t, "?uint_slice=-1", `invalid value for query parameter "uint_slice": element 0: strconv.ParseUint: parsing "-1": invalid syntax`)
+	checkParsingError(t, "?uint8_slice=-1", `invalid value for query parameter "uint8_slice": element 0: strconv.ParseUint: parsing "-1": invalid syntax`)
+	checkParsingError(t, "?uint16_slice=-1", `invalid value for query parameter "uint16_slice": element 0: strconv.ParseUint: parsing "-1": invalid syntax`)
+	checkParsingError(t, "?uint32_slice=-1", `invalid value for query parameter "uint32_slice": element 0: strconv.ParseUint: parsing "-1": invalid syntax`)
+	checkParsingError(t, "?uint64_slice=-1", `invalid value for query parameter "uint64_slice": element 0: strconv.ParseUint: parsing "-1": invalid syntax`)
+
+	// slice float overflows
+	checkParsingError(t, "?float32_slice="+overflowFloat32Query, fmt.Sprintf(`invalid value for query parameter "float32_slice": element 0: strconv.ParseFloat: parsing "%s": value out of range`, overflowFloat32))
+	checkParsingError(t, "?float64_slice="+overflowFloat64Query, fmt.Sprintf(`invalid value for query parameter "float64_slice": element 0: strconv.ParseFloat: parsing "%s": value out of range`, overflowFloat64))
+
+	// slice float underflows (negative overflow)
+	checkParsingError(t, "?float32_slice="+underflowFloat32Query, fmt.Sprintf(`invalid value for query parameter "float32_slice": element 0: strconv.ParseFloat: parsing "%s": value out of range`, underflowFloat32))
+	checkParsingError(t, "?float64_slice="+underflowFloat64Query, fmt.Sprintf(`invalid value for query parameter "float64_slice": element 0: strconv.ParseFloat: parsing "%s": value out of range`, underflowFloat64))
+
+	// option int overflows
+	checkParsingError(t, "?option_int="+strconv.FormatUint(maxIntPlus1, 10), fmt.Sprintf(`invalid value for query parameter "option_int": strconv.ParseInt: parsing "%d": value out of range`, maxIntPlus1))
+	checkParsingError(t, "?option_int8="+strconv.FormatUint(maxInt8Plus1, 10), fmt.Sprintf(`invalid value for query parameter "option_int8": strconv.ParseInt: parsing "%d": value out of range`, maxInt8Plus1))
+	checkParsingError(t, "?option_int16="+strconv.FormatUint(maxInt16Plus1, 10), fmt.Sprintf(`invalid value for query parameter "option_int16": strconv.ParseInt: parsing "%d": value out of range`, maxInt16Plus1))
+	checkParsingError(t, "?option_int32="+strconv.FormatUint(maxInt32Plus1, 10), fmt.Sprintf(`invalid value for query parameter "option_int32": strconv.ParseInt: parsing "%d": value out of range`, maxInt32Plus1))
+	checkParsingError(t, "?option_int64="+strconv.FormatUint(maxInt64Plus1, 10), fmt.Sprintf(`invalid value for query parameter "option_int64": strconv.ParseInt: parsing "%d": value out of range`, maxInt64Plus1))
+
+	// option int underflows
+	checkParsingError(t, "?option_int="+minIntMinus1, fmt.Sprintf(`invalid value for query parameter "option_int": strconv.ParseInt: parsing "%s": value out of range`, minIntMinus1))
+	checkParsingError(t, "?option_int8="+minInt8Minus1, fmt.Sprintf(`invalid value for query parameter "option_int8": strconv.ParseInt: parsing "%s": value out of range`, minInt8Minus1))
+	checkParsingError(t, "?option_int16="+minInt16Minus1, fmt.Sprintf(`invalid value for query parameter "option_int16": strconv.ParseInt: parsing "%s": value out of range`, minInt16Minus1))
+	checkParsingError(t, "?option_int32="+minInt32Minus1, fmt.Sprintf(`invalid value for query parameter "option_int32": strconv.ParseInt: parsing "%s": value out of range`, minInt32Minus1))
+	checkParsingError(t, "?option_int64="+minInt64Minus1, fmt.Sprintf(`invalid value for query parameter "option_int64": strconv.ParseInt: parsing "%s": value out of range`, minInt64Minus1))
+
+	// option float overflows
+	checkParsingError(t, "?option_float32="+overflowFloat32Query, fmt.Sprintf(`invalid value for query parameter "option_float32": strconv.ParseFloat: parsing "%s": value out of range`, overflowFloat32))
+	checkParsingError(t, "?option_float64="+overflowFloat64Query, fmt.Sprintf(`invalid value for query parameter "option_float64": strconv.ParseFloat: parsing "%s": value out of range`, overflowFloat64))
+
+	// option float underflows (negative overflow)
+	checkParsingError(t, "?option_float32="+underflowFloat32Query, fmt.Sprintf(`invalid value for query parameter "option_float32": strconv.ParseFloat: parsing "%s": value out of range`, underflowFloat32))
+	checkParsingError(t, "?option_float64="+underflowFloat64Query, fmt.Sprintf(`invalid value for query parameter "option_float64": strconv.ParseFloat: parsing "%s": value out of range`, underflowFloat64))
+
+	// option uint overflows
+	checkParsingError(t, "?option_uint="+maxUintPlus1, fmt.Sprintf(`invalid value for query parameter "option_uint": strconv.ParseUint: parsing "%s": value out of range`, maxUintPlus1))
+	checkParsingError(t, "?option_uint8="+maxUint8Plus1, fmt.Sprintf(`invalid value for query parameter "option_uint8": strconv.ParseUint: parsing "%s": value out of range`, maxUint8Plus1))
+	checkParsingError(t, "?option_uint16="+maxUint16Plus1, fmt.Sprintf(`invalid value for query parameter "option_uint16": strconv.ParseUint: parsing "%s": value out of range`, maxUint16Plus1))
+	checkParsingError(t, "?option_uint32="+maxUint32Plus1, fmt.Sprintf(`invalid value for query parameter "option_uint32": strconv.ParseUint: parsing "%s": value out of range`, maxUint32Plus1))
+	checkParsingError(t, "?option_uint64="+maxUintPlus1, fmt.Sprintf(`invalid value for query parameter "option_uint64": strconv.ParseUint: parsing "%s": value out of range`, maxUintPlus1))
+
+	// option uint underflows (negative values rejected)
+	checkParsingError(t, "?option_uint=-1", `invalid value for query parameter "option_uint": strconv.ParseUint: parsing "-1": invalid syntax`)
+	checkParsingError(t, "?option_uint8=-1", `invalid value for query parameter "option_uint8": strconv.ParseUint: parsing "-1": invalid syntax`)
+	checkParsingError(t, "?option_uint16=-1", `invalid value for query parameter "option_uint16": strconv.ParseUint: parsing "-1": invalid syntax`)
+	checkParsingError(t, "?option_uint32=-1", `invalid value for query parameter "option_uint32": strconv.ParseUint: parsing "-1": invalid syntax`)
+	checkParsingError(t, "?option_uint64=-1", `invalid value for query parameter "option_uint64": strconv.ParseUint: parsing "-1": invalid syntax`)
+
+	// pointer uint overflows
+	checkParsingError(t, "?pointer_uint="+maxUintPlus1, fmt.Sprintf(`invalid value for query parameter "pointer_uint": strconv.ParseUint: parsing "%s": value out of range`, maxUintPlus1))
+	checkParsingError(t, "?pointer_uint8="+maxUint8Plus1, fmt.Sprintf(`invalid value for query parameter "pointer_uint8": strconv.ParseUint: parsing "%s": value out of range`, maxUint8Plus1))
+	checkParsingError(t, "?pointer_uint16="+maxUint16Plus1, fmt.Sprintf(`invalid value for query parameter "pointer_uint16": strconv.ParseUint: parsing "%s": value out of range`, maxUint16Plus1))
+	checkParsingError(t, "?pointer_uint32="+maxUint32Plus1, fmt.Sprintf(`invalid value for query parameter "pointer_uint32": strconv.ParseUint: parsing "%s": value out of range`, maxUint32Plus1))
+	checkParsingError(t, "?pointer_uint64="+maxUintPlus1, fmt.Sprintf(`invalid value for query parameter "pointer_uint64": strconv.ParseUint: parsing "%s": value out of range`, maxUintPlus1))
+
+	// pointer uint underflows (negative values rejected)
+	checkParsingError(t, "?pointer_uint=-1", `invalid value for query parameter "pointer_uint": strconv.ParseUint: parsing "-1": invalid syntax`)
+	checkParsingError(t, "?pointer_uint8=-1", `invalid value for query parameter "pointer_uint8": strconv.ParseUint: parsing "-1": invalid syntax`)
+	checkParsingError(t, "?pointer_uint16=-1", `invalid value for query parameter "pointer_uint16": strconv.ParseUint: parsing "-1": invalid syntax`)
+	checkParsingError(t, "?pointer_uint32=-1", `invalid value for query parameter "pointer_uint32": strconv.ParseUint: parsing "-1": invalid syntax`)
+	checkParsingError(t, "?pointer_uint64=-1", `invalid value for query parameter "pointer_uint64": strconv.ParseUint: parsing "-1": invalid syntax`)
+}

--- a/opts/parse_test.go
+++ b/opts/parse_test.go
@@ -19,10 +19,17 @@ import (
 	"github.com/sapcc/go-api-declarations/opts"
 )
 
+type EmbeddedOpts struct {
+	EmbeddedString string `q:"embedded_string"`
+}
+
 type testOpts struct {
+	EmbeddedOpts
 	StringMap      map[string]string `q:"string_map"`
+	IntStringMap   map[int]string    `q:"int_string_map"`
+	StringIntMap   map[string]int    `q:"string_int_map"`
 	Bool           bool              `q:"bool"`
-	Time           time.Time         `q:"time"`
+	Time           time.Time         `q:"time,format:RFC3339"`
 	String         string            `q:"string"`
 	Int            int               `q:"int"`
 	Int8           int8              `q:"int8"`
@@ -37,7 +44,7 @@ type testOpts struct {
 	Float32        float32           `q:"float32"`
 	Float64        float64           `q:"float64"`
 	PointerBool    *bool             `q:"pointer_bool"`
-	PointerTime    *time.Time        `q:"pointer_time"`
+	PointerTime    *time.Time        `q:"pointer_time,format:RFC3339"`
 	PointerString  *string           `q:"pointer_string"`
 	PointerInt     *int              `q:"pointer_int"`
 	PointerInt8    *int8             `q:"pointer_int8"`
@@ -52,7 +59,7 @@ type testOpts struct {
 	PointerFloat32 *float32          `q:"pointer_float32"`
 	PointerFloat64 *float64          `q:"pointer_float64"`
 	BoolSlice      []bool            `q:"bool_slice"`
-	TimeSlice      []time.Time       `q:"time_slice"`
+	TimeSlice      []time.Time       `q:"time_slice,format:RFC3339"`
 	StringSlice    []string          `q:"string_slice"`
 	IntSlice       []int             `q:"int_slice"`
 	Int8Slice      []int8            `q:"int8_slice"`
@@ -67,7 +74,7 @@ type testOpts struct {
 	Float32Slice   []float32         `q:"float32_slice"`
 	Float64Slice   []float64         `q:"float64_slice"`
 	OptionBool     Option[bool]      `q:"option_bool"`
-	OptionTime     Option[time.Time] `q:"option_time"`
+	OptionTime     Option[time.Time] `q:"option_time,format:RFC3339"`
 	OptionString   Option[string]    `q:"option_string"`
 	OptionInt      Option[int]       `q:"option_int"`
 	OptionInt8     Option[int8]      `q:"option_int8"`
@@ -86,7 +93,7 @@ type testOpts struct {
 func checkParsingHappyPath(t *testing.T, variable, query string, result testOpts) {
 	t.Helper()
 	r := httptest.NewRequest(http.MethodGet, "/some/unimportant/path"+query, http.NoBody)
-	to, err := opts.ParseQueryString[testOpts](r)
+	to, err := opts.ParseQueryString[testOpts](r.URL.Query())
 	if err != nil {
 		t.Fatal(variable + ": " + err.Error())
 	}
@@ -97,54 +104,36 @@ func TestOptParserHappyPaths(t *testing.T) {
 	// empty query
 	checkParsingHappyPath(t, "empty opts", "", testOpts{})
 
+	// embedded string
+	checkParsingHappyPath(t, "embedded_string", "?embedded_string=hello",
+		testOpts{EmbeddedOpts: EmbeddedOpts{EmbeddedString: "hello"}})
+
 	// map
 	checkParsingHappyPath(t, "string_map", "?string_map=k1:v1&string_map=k2:v2",
 		testOpts{StringMap: map[string]string{"k1": "v1", "k2": "v2"}})
+	checkParsingHappyPath(t, "int_string_map", "?int_string_map=1:foo&int_string_map=2:bar",
+		testOpts{IntStringMap: map[int]string{1: "foo", 2: "bar"}})
+	checkParsingHappyPath(t, "string_int_map", "?string_int_map=foo:1&string_int_map=bar:2",
+		testOpts{StringIntMap: map[string]int{"foo": 1, "bar": 2}})
 
 	// time
-	checkParsingHappyPath(t, "time RFC3339Nano", "?time=2000-01-01T00:00:00.000000000Z",
-		testOpts{Time: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)})
 	checkParsingHappyPath(t, "time RFC3339", "?time=2000-01-01T00:00:00Z",
-		testOpts{Time: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)})
-	checkParsingHappyPath(t, "time DateTime", "?time=2000-01-01%2000:00:00",
-		testOpts{Time: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)})
-	checkParsingHappyPath(t, "time Date", "?time=2000-01-01",
-		testOpts{Time: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)})
-	checkParsingHappyPath(t, "time Unix", "?time=946684800",
 		testOpts{Time: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)})
 
 	// pointer time
-	checkParsingHappyPath(t, "pointer time RFC3339Nano", "?pointer_time=2000-01-01T00:00:00.000000000Z",
-		testOpts{PointerTime: new(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC))})
 	checkParsingHappyPath(t, "pointer time RFC3339", "?pointer_time=2000-01-01T00:00:00Z",
-		testOpts{PointerTime: new(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC))})
-	checkParsingHappyPath(t, "pointer time DateTime", "?pointer_time=2000-01-01%2000:00:00",
-		testOpts{PointerTime: new(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC))})
-	checkParsingHappyPath(t, "pointer time Date", "?pointer_time=2000-01-01",
-		testOpts{PointerTime: new(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC))})
-	checkParsingHappyPath(t, "pointer time Unix", "?pointer_time=946684800",
 		testOpts{PointerTime: new(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC))})
 
 	// time slice
-	checkParsingHappyPath(t, "slice time (all formats)", "?time_slice=2000-01-01T00:00:00.000000000Z&time_slice=2001-01-01T00:00:00Z&time_slice=2002-01-01%2000:00:00&time_slice=2003-01-01&time_slice=1072915200",
+	checkParsingHappyPath(t, "slice time RFC3339", "?time_slice=2000-01-01T00:00:00Z&time_slice=2001-01-01T00:00:00Z&time_slice=2002-01-01T00:00:00Z",
 		testOpts{TimeSlice: []time.Time{
 			time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC),
 			time.Date(2001, 1, 1, 0, 0, 0, 0, time.UTC),
 			time.Date(2002, 1, 1, 0, 0, 0, 0, time.UTC),
-			time.Date(2003, 1, 1, 0, 0, 0, 0, time.UTC),
-			time.Date(2004, 1, 1, 0, 0, 0, 0, time.UTC),
 		}})
 
 	// option time
-	checkParsingHappyPath(t, "option time RFC3339Nano", "?option_time=2000-01-01T00:00:00.000000000Z",
-		testOpts{OptionTime: Some(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC))})
 	checkParsingHappyPath(t, "option time RFC3339", "?option_time=2000-01-01T00:00:00Z",
-		testOpts{OptionTime: Some(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC))})
-	checkParsingHappyPath(t, "option time DateTime", "?option_time=2000-01-01%2000:00:00",
-		testOpts{OptionTime: Some(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC))})
-	checkParsingHappyPath(t, "option time Date", "?option_time=2000-01-01",
-		testOpts{OptionTime: Some(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC))})
-	checkParsingHappyPath(t, "option time Unix", "?option_time=946684800",
 		testOpts{OptionTime: Some(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC))})
 
 	// plain scalars
@@ -251,7 +240,7 @@ func checkParsingPanic(t *testing.T, panicMsg string, fn func()) {
 func checkParsingError(t *testing.T, query, errMsg string) {
 	t.Helper()
 	r := httptest.NewRequest(http.MethodGet, "/some/unimportant/path"+query, http.NoBody)
-	_, resultingError := opts.ParseQueryString[testOpts](r)
+	_, resultingError := opts.ParseQueryString[testOpts](r.URL.Query())
 	th.AssertErr(t, errMsg, resultingError)
 }
 
@@ -259,7 +248,7 @@ func TestOptParserErrors(t *testing.T) {
 	// non-struct type parameter (panics)
 	r := httptest.NewRequest(http.MethodGet, "/some/unimportant/path", http.NoBody)
 	checkParsingPanic(t, "expected opts to point to a struct", func() {
-		opts.ParseQueryString[int](r) //nolint:errcheck // won't get to this part
+		opts.ParseQueryString[int](r.URL.Query()) //nolint:errcheck // won't get to this part
 	})
 
 	// missing q-tag (panics)
@@ -267,19 +256,27 @@ func TestOptParserErrors(t *testing.T) {
 		String string `yaml:"string"`
 	}
 	checkParsingPanic(t, `expected "String" to have a "q:"-tag`, func() {
-		opts.ParseQueryString[testNonOpts](r) //nolint:errcheck // won't get to this part
+		opts.ParseQueryString[testNonOpts](r.URL.Query()) //nolint:errcheck // won't get to this part
+	})
+
+	// embedded struct with q-tag (panics)
+	type testEmbeddedQTagOpts struct {
+		EmbeddedOpts `q:"embedded"`
+	}
+	checkParsingPanic(t, `expected embedded struct "EmbeddedOpts" to have no "q:"-tag`, func() {
+		opts.ParseQueryString[testEmbeddedQTagOpts](r.URL.Query()) //nolint:errcheck // won't get to this part
 	})
 
 	// missing required parameter
 	type testStringRequiredOpts struct {
 		String string `q:"string,required"`
 	}
-	_, resultingError := opts.ParseQueryString[testStringRequiredOpts](r)
+	_, resultingError := opts.ParseQueryString[testStringRequiredOpts](r.URL.Query())
 	th.AssertErr(t, `missing value for query parameter "string"`, resultingError)
 	type testStringSliceRequiredOpts struct {
 		StringSlice []string `q:"string_slice,required"`
 	}
-	_, resultingError = opts.ParseQueryString[testStringSliceRequiredOpts](r)
+	_, resultingError = opts.ParseQueryString[testStringSliceRequiredOpts](r.URL.Query())
 	th.AssertErr(t, `missing value for query parameter "string_slice"`, resultingError)
 
 	// unknown parameter
@@ -289,10 +286,10 @@ func TestOptParserErrors(t *testing.T) {
 	checkParsingError(t, "?string_map=foo", `invalid value for query parameter "string_map": invalid map entry "foo": expected key:value`)
 
 	// wrong type: time
-	checkParsingError(t, "?time=foo", `invalid value for query parameter "time": cannot parse "foo" as time; accepted: DateOnly, DateTime, RFC3339, RFC3339Nano, Unix`)
-	checkParsingError(t, "?pointer_time=foo", `invalid value for query parameter "pointer_time": cannot parse "foo" as time; accepted: DateOnly, DateTime, RFC3339, RFC3339Nano, Unix`)
-	checkParsingError(t, "?time_slice=foo", `invalid value for query parameter "time_slice": element 0: cannot parse "foo" as time; accepted: DateOnly, DateTime, RFC3339, RFC3339Nano, Unix`)
-	checkParsingError(t, "?option_time=foo", `invalid value for query parameter "option_time": cannot parse "foo" as time; accepted: DateOnly, DateTime, RFC3339, RFC3339Nano, Unix`)
+	checkParsingError(t, "?time=foo", `invalid value for query parameter "time": cannot parse "foo" as RFC3339: parsing time "foo" as "2006-01-02T15:04:05Z07:00": cannot parse "foo" as "2006"`)
+	checkParsingError(t, "?pointer_time=foo", `invalid value for query parameter "pointer_time": cannot parse "foo" as RFC3339: parsing time "foo" as "2006-01-02T15:04:05Z07:00": cannot parse "foo" as "2006"`)
+	checkParsingError(t, "?time_slice=foo", `invalid value for query parameter "time_slice": element 0: cannot parse "foo" as RFC3339: parsing time "foo" as "2006-01-02T15:04:05Z07:00": cannot parse "foo" as "2006"`)
+	checkParsingError(t, "?option_time=foo", `invalid value for query parameter "option_time": cannot parse "foo" as RFC3339: parsing time "foo" as "2006-01-02T15:04:05Z07:00": cannot parse "foo" as "2006"`)
 
 	// multiple values: time
 	checkParsingError(t, "?time=2000-01-01&time=2001-01-01", `invalid value for query parameter "time": expected a single value, got 2`)
@@ -305,18 +302,21 @@ func TestOptParserErrors(t *testing.T) {
 	checkParsingError(t, "?option_bool=foo", `invalid value for query parameter "option_bool": strconv.ParseBool: parsing "foo": invalid syntax`)
 	checkParsingError(t, "?bool_slice=foo", `invalid value for query parameter "bool_slice": element 0: strconv.ParseBool: parsing "foo": invalid syntax`)
 
-	// wrong format: time
+	// wrong time format
+	checkParsingError(t, "?time=2000-01-01", `invalid value for query parameter "time": cannot parse "2000-01-01" as RFC3339: parsing time "2000-01-01" as "2006-01-02T15:04:05Z07:00": cannot parse "" as "T"`)
 	r = httptest.NewRequest(http.MethodGet, "/some/unimportant/path?time=2000-01-01%2000:00", http.NoBody)
 	type testImpossibleTimeFormatOpts struct {
 		Time time.Time `q:"time,format:foo"`
 	}
-	_, resultingError = opts.ParseQueryString[testImpossibleTimeFormatOpts](r)
-	th.AssertErr(t, `unsupported time format "foo"; accepted: DateOnly, DateTime, RFC3339, RFC3339Nano, Unix`, resultingError)
-	type testTimeFormatOpts struct {
-		Time time.Time `q:"time,format:RFC3339"`
+	checkParsingPanic(t, `unsupported time format "foo"; accepted: DateOnly, DateTime, RFC3339, RFC3339Nano, Unix`, func() {
+		opts.ParseQueryString[testImpossibleTimeFormatOpts](r.URL.Query()) //nolint:errcheck // won't get to this part
+	})
+	type testMissingTimeFormatOpts struct {
+		Time time.Time `q:"time"`
 	}
-	_, resultingError = opts.ParseQueryString[testTimeFormatOpts](r)
-	th.AssertErr(t, `invalid value for query parameter "time": cannot parse "2000-01-01 00:00" as RFC3339: parsing time "2000-01-01 00:00" as "2006-01-02T15:04:05Z07:00": cannot parse " 00:00" as "T"`, resultingError)
+	checkParsingPanic(t, `time format is missing for field Time`, func() {
+		opts.ParseQueryString[testMissingTimeFormatOpts](r.URL.Query()) //nolint:errcheck // won't get to this part
+	})
 
 	// wrong type: numbers
 	checkParsingError(t, "?int=foo", `invalid value for query parameter "int": strconv.ParseInt: parsing "foo": invalid syntax`)

--- a/opts/parse_test.go
+++ b/opts/parse_test.go
@@ -245,8 +245,9 @@ func checkParsingError(t *testing.T, query, errMsg string) {
 }
 
 func TestOptParserErrors(t *testing.T) {
-	// non-struct type parameter (panics)
 	r := httptest.NewRequest(http.MethodGet, "/some/unimportant/path", http.NoBody)
+
+	// non-struct type parameter (panics)
 	checkParsingPanic(t, "expected opts to point to a struct", func() {
 		opts.ParseQueryString[int](r.URL.Query()) //nolint:errcheck // won't get to this part
 	})

--- a/opts/serialize.go
+++ b/opts/serialize.go
@@ -9,11 +9,12 @@ import (
 	"reflect"
 	"slices"
 	"strconv"
+	"strings"
 	"time"
 )
 
 // BuildQueryString is a function to be used by request methods with opts structs.
-// It's inspired by gophercloud.BuildQueryString with partially stricter behavior.
+// It's inspired by [gophercloud.BuildQueryString] with partially stricter behavior.
 // It accepts a tagged structure and expands it into a URL struct. Field names are
 // converted into query parameters based on a "q" tag. For example:
 //
@@ -26,31 +27,20 @@ import (
 //	   Baz: "BBB",
 //	}
 //
-// will be converted into "?x_bar=AAA&lorem_ipsum=BBB".
+// will be converted into
+//
+//	?x_bar=AAA&lorem_ipsum=BBB
 //
 // On configuration errors (e.g. non-struct opts, opts with non-q-tagged fields)
 // the function panics. On user errors (e.g. missing required field) an error
 // is returned. On success, url.Values are returned according to the opts.
 //
-// The serialization supports all scalars except complex. Structs of scalars are supported
-// and special structs like time.Time. Additionally, it allows Slices (for multiple
-// values), option.Option (recommended for optional values) and pointers (as alternative
-// to option.Option) of these. Only map[string]string is supported as a map type.
-// Fields left at their type's zero value will be omitted from the query.
+// This function understands and expects the same values for the "q" tag as [BuildQueryString].
+// See documentation over there for details.
 //
-// Slice fields use repeated query parameters:
-// Foo []string `q:"foo"`                       // ?foo=a&foo=b
+// [gophercloud.BuildQueryString]: https://pkg.go.dev/github.com/gophercloud/gophercloud/v2#BuildQueryString
 //
-// Map fields accept plain repeated key:value pairs:
-// Bar map[string]string `q:"bar"`              // ?bar=k1:v1&bar=k2:v2
-//
-// time.Time fields support the formats RFC3339Nano, RFC3339, DateTime, Date, Unix.
-// A single `format` option can be set, to define what is used for serialization, otherwise
-// the default RFC3339 gets used:
-// Baz time.Time `q:"baz,format:DateTime"`       // ?baz=1999-01-01 00:00:00
-//
-// A `required` option can be set to define that a missing value will produce an error.
-// Quux string `q:"quux,required"`               // ?foo=bar --> error
+// [option.Option]: https://pkg.go.dev/go.xyrillian.de/gg/option#Option
 func BuildQueryString(opts any) (url.Values, error) {
 	optsValue := reflect.ValueOf(opts)
 	if optsValue.Kind() == reflect.Ptr { //nolint: govet // won't inline this...
@@ -65,10 +55,21 @@ func BuildQueryString(opts any) (url.Values, error) {
 	for _, field := range reflect.VisibleFields(optsType) {
 		fieldValue := optsValue.FieldByIndex(field.Index)
 		qTag := field.Tag.Get("q")
+		if field.Anonymous {
+			// this is for struct embedding to work
+			if qTag != "" {
+				panic(fmt.Sprintf(`expected embedded struct %q to have no "q:"-tag`, field.Name))
+			}
+			continue
+		}
 		if qTag == "" {
 			panic(fmt.Sprintf(`expected %q to have a "q:"-tag`, field.Name))
 		}
-		key, format, required := parseQTag(qTag)
+		key, timeFormat, required := parseQTag(qTag)
+		// all known formats are currently timeFormats
+		if _, ok := TimeFormats[timeFormat]; timeFormat != "" && timeFormat != UnixFormat && !ok {
+			panic(fmt.Sprintf("unsupported time format %q; accepted: %s", timeFormat, supportedHumanReadableFormats))
+		}
 
 		// if field not set, skip
 		if isZero(fieldValue) {
@@ -94,35 +95,34 @@ func BuildQueryString(opts any) (url.Values, error) {
 		case reflect.Float32, reflect.Float64:
 			params.Add(key, strconv.FormatFloat(fieldValue.Float(), 'g', -1, fieldValue.Type().Bits()))
 		case reflect.Slice:
-			var values []string
+			values := make([]string, fieldValue.Len())
 			for i := range fieldValue.Len() {
-				values = append(values, serializeValue(fieldValue.Index(i), format))
+				values[i] = serializeValue(fieldValue.Index(i), timeFormat)
 			}
 			params[key] = append(params[key], values...)
 		case reflect.Struct:
 			if fieldValue.Type() == reflect.TypeFor[time.Time]() {
-				params.Add(key, serializeValue(fieldValue, format))
+				if timeFormat == "" {
+					panic("time format is missing")
+				}
+				params.Add(key, serializeValue(fieldValue, timeFormat))
 			} else if m := fieldValue.MethodByName("AsPointer"); m.IsValid() {
 				// Option[T] — unwrap via AsPointer
 				results := m.Call(nil)
 				if len(results) == 1 && results[0].Kind() == reflect.Ptr && !results[0].IsNil() { //nolint:govet // won't inline this...
-					params.Add(key, serializeValue(results[0].Elem(), format))
+					params.Add(key, serializeValue(results[0].Elem(), timeFormat))
 				}
 			} else {
 				// defense in depth: already handled by isZero function
 				panic("for structs only time.Time and implementers of isZeroer are supported")
 			}
 		case reflect.Map:
-			if fieldValue.Type().Key().Kind() == reflect.String && fieldValue.Type().Elem().Kind() == reflect.String {
-				keys := make([]string, 0, fieldValue.Len())
-				for _, k := range fieldValue.MapKeys() {
-					keys = append(keys, k.String())
-				}
-				slices.Sort(keys)
-				for _, k := range keys {
-					value := fieldValue.MapIndex(reflect.ValueOf(k)).String()
-					params.Add(key, k+":"+value)
-				}
+			keys := fieldValue.MapKeys()
+			slices.SortFunc(keys, func(a, b reflect.Value) int {
+				return strings.Compare(serializeValue(a, ""), serializeValue(b, ""))
+			})
+			for _, k := range keys {
+				params.Add(key, serializeValue(k, "")+":"+serializeValue(fieldValue.MapIndex(k), ""))
 			}
 		}
 	}
@@ -130,7 +130,7 @@ func BuildQueryString(opts any) (url.Values, error) {
 }
 
 // serializeValue converts a reflect.Value to its string representation for query parameters.
-func serializeValue(v reflect.Value, format string) string {
+func serializeValue(v reflect.Value, timeFormat string) string {
 	// Dereference pointers.
 	for v.Kind() == reflect.Ptr { //nolint:govet // won't inline this...
 		v = v.Elem()
@@ -149,15 +149,14 @@ func serializeValue(v reflect.Value, format string) string {
 	case reflect.Struct:
 		if v.Type() == reflect.TypeFor[time.Time]() {
 			t := v.Interface().(time.Time)
-			switch format {
-			case "":
-				return t.Format(time.RFC3339)
-			case unixFormat:
+			switch timeFormat {
+			case UnixFormat:
 				return strconv.FormatInt(t.Unix(), 10)
 			default:
-				tf, exists := timeFormats[format]
+				tf, exists := TimeFormats[timeFormat]
+				// defense in depth: should be checked outside of this function (when no value is set)
 				if !exists {
-					panic("unknown time format " + format)
+					panic("unknown time format " + timeFormat)
 				}
 				return t.Format(tf)
 			}
@@ -166,7 +165,7 @@ func serializeValue(v reflect.Value, format string) string {
 		if m := v.MethodByName("AsPointer"); m.IsValid() {
 			results := m.Call(nil)
 			if len(results) == 1 && results[0].Kind() == reflect.Ptr && !results[0].IsNil() { //nolint:govet // won't inline this...
-				return serializeValue(results[0].Elem(), format)
+				return serializeValue(results[0].Elem(), timeFormat)
 			}
 		}
 	}

--- a/opts/serialize.go
+++ b/opts/serialize.go
@@ -55,6 +55,14 @@ func BuildQueryString(opts any) (url.Values, error) {
 	if optsValue.Kind() != reflect.Struct {
 		panic("options type is not a struct")
 	}
+
+	// Collect value-discriminant fields (bool fields with "value:" option) separately.
+	type valueField struct {
+		fieldValue reflect.Value
+		value      string
+	}
+	valueDiscriminantFields := make(map[string][]valueField)
+
 	for _, field := range reflect.VisibleFields(optsType) {
 		fieldValue := optsValue.FieldByIndex(field.Index)
 		qTag := field.Tag.Get("q")
@@ -68,11 +76,23 @@ func BuildQueryString(opts any) (url.Values, error) {
 		if qTag == "" {
 			panic(fmt.Sprintf(`expected %q to have a "q:"-tag`, field.Name))
 		}
-		key, maybeTimeFormat, required := parseQTag(qTag)
+		key, maybeTimeFormat, maybeValue, required := parseQTag(qTag)
 
 		// check if format is set when required
 		if typeNeedsTimeFormat(fieldValue.Type()) && maybeTimeFormat.IsNone() {
 			panic(fmt.Sprintf(`time format is missing for field %q`, field.Name))
+		}
+
+		// value-discriminant fields: collect and skip normal processing
+		if value, ok := maybeValue.Unpack(); ok {
+			if fieldValue.Kind() != reflect.Bool {
+				panic(fmt.Sprintf(`field %q has "value:" option but is not a bool`, field.Name))
+			}
+			valueDiscriminantFields[key] = append(valueDiscriminantFields[key], valueField{
+				fieldValue: fieldValue,
+				value:      value,
+			})
+			continue
 		}
 
 		// if field not set, skip
@@ -120,6 +140,16 @@ func BuildQueryString(opts any) (url.Values, error) {
 			return url.Values{}, fmt.Errorf("required query parameter [%s] not set", field.Name)
 		}
 	}
+
+	// Serialize value-discriminant fields: true bools emit their value string.
+	for key, vfs := range valueDiscriminantFields {
+		for _, vf := range vfs {
+			if vf.fieldValue.Bool() {
+				params.Add(key, vf.value)
+			}
+		}
+	}
+
 	return params, nil
 }
 

--- a/opts/serialize.go
+++ b/opts/serialize.go
@@ -20,7 +20,7 @@ import (
 // It accepts a tagged structure and expands it into a URL struct. Field names are
 // converted into query parameters based on a "q" tag. For example:
 //
-//	type struct Something {
+//	type Something struct {
 //	   Bar string `q:"x_bar"`
 //	   Baz int    `q:"lorem_ipsum"`
 //	}
@@ -76,6 +76,9 @@ func BuildQueryString(opts any) (url.Values, error) {
 		}
 		if qTag == "" {
 			panic(fmt.Sprintf(`expected %q to have a "q:"-tag`, field.Name))
+		}
+		if !fieldValue.CanInterface() {
+			panic(fmt.Sprintf(`field %q is unexported and therefore cannot be read`, field.Name))
 		}
 		key, maybeTimeFormat, maybeValue, required := parseQTag(qTag)
 
@@ -164,7 +167,7 @@ func BuildQueryString(opts any) (url.Values, error) {
 }
 
 // serializeSingleValue converts a reflect.Value to its string representation for query parameters.
-// Zero values are skipped.
+// Zero values are serialized, also - so they need to be taken care of separately, if that is no intentional.
 func serializeSingleValue(v reflect.Value, timeFormat Option[string]) string {
 	// Dereference pointers.
 	for v.Kind() == reflect.Pointer {

--- a/opts/serialize.go
+++ b/opts/serialize.go
@@ -43,7 +43,7 @@ import (
 // [gophercloud.BuildQueryString]: https://pkg.go.dev/github.com/gophercloud/gophercloud/v2#BuildQueryString
 func BuildQueryString(opts any) (url.Values, error) {
 	optsValue := reflect.ValueOf(opts)
-	if optsValue.Kind() == reflect.Ptr { //nolint: govet // won't inline this...
+	if optsValue.Kind() == reflect.Pointer {
 		if optsValue.IsNil() {
 			panic("opts is a nil pointer")
 		}
@@ -101,7 +101,7 @@ func BuildQueryString(opts any) (url.Values, error) {
 		}
 	loop:
 		switch fieldValue.Kind() {
-		case reflect.Ptr: //nolint: govet // won't inline this...
+		case reflect.Pointer:
 			fieldValue = fieldValue.Elem()
 			goto loop
 		// only handle non-single-values here, rest is done by serializeSingleValue()
@@ -117,12 +117,12 @@ func BuildQueryString(opts any) (url.Values, error) {
 			} else if m := fieldValue.MethodByName("AsPointer"); m.IsValid() {
 				// Option[T] — unwrap via AsPointer
 				results := m.Call(nil)
-				if len(results) == 1 && results[0].Kind() == reflect.Ptr && !results[0].IsNil() { //nolint:govet // won't inline this...
+				if len(results) == 1 && results[0].Kind() == reflect.Pointer && !results[0].IsNil() {
 					params.Add(key, serializeSingleValue(results[0].Elem(), maybeTimeFormat))
 				}
 			} else {
 				// defense in depth: already handled by canBeSkipped function
-				panic("for structs only implementers of isZeroer are supported")
+				panic("structs other than time.Time and option.Option[T] are not supported")
 			}
 		case reflect.Map:
 			keys := fieldValue.MapKeys()
@@ -157,7 +157,7 @@ func BuildQueryString(opts any) (url.Values, error) {
 // Zero values are skipped.
 func serializeSingleValue(v reflect.Value, timeFormat Option[string]) string {
 	// Dereference pointers.
-	for v.Kind() == reflect.Ptr { //nolint:govet // won't inline this...
+	for v.Kind() == reflect.Pointer {
 		v = v.Elem()
 	}
 	switch v.Kind() {
@@ -187,7 +187,7 @@ func serializeSingleValue(v reflect.Value, timeFormat Option[string]) string {
 		// handle Option[T]: try to unwrap via AsPointer() method.
 		if m := v.MethodByName("AsPointer"); m.IsValid() {
 			results := m.Call(nil)
-			if len(results) == 1 && results[0].Kind() == reflect.Ptr && !results[0].IsNil() { //nolint:govet // won't inline this...
+			if len(results) == 1 && results[0].Kind() == reflect.Pointer && !results[0].IsNil() {
 				return serializeSingleValue(results[0].Elem(), timeFormat)
 			}
 		}
@@ -198,36 +198,38 @@ func serializeSingleValue(v reflect.Value, timeFormat Option[string]) string {
 // canBeSkipped checks if a value can be skipped for serialization into a query string.
 // Required params are never skipped. Otherwise, isZero() of the value is checked.
 // Special handling is applied to
-// - structs (check isZero() interface)
-// - slices, arrays, maps (considered zero when nil or all values are zero)
+// - structs (only time.Time and Option[T] are supported; others panic)
+// - pointers (nil means skippable)
 func canBeSkipped(v reflect.Value, required bool) bool {
+	// reject functions
+	if v.Kind() == reflect.Func {
+		panic("functions are not supported")
+	}
+
 	if required {
 		return false
 	}
+
 	// check pointers
-	if v.Kind() == reflect.Ptr { //nolint:govet // won't inline this...
+	if v.Kind() == reflect.Pointer {
 		if v.IsNil() {
-			// Guard against nil pointers whose element type has pointer-receiver IsZero.
 			return true
 		}
 		// Dereference the pointer and check the element.
 		return canBeSkipped(v.Elem(), false)
 	}
 
-	// check for types implementing IsZero() bool (e.g. Option[T], time.Time).
-	if v.CanInterface() {
-		type isZeroer interface{ IsZero() bool }
-		if z, ok := v.Interface().(isZeroer); ok {
-			return z.IsZero()
+	// structs: only time.Time and Option[T] are supported
+	if v.Kind() == reflect.Struct {
+		if v.Type() == reflect.TypeFor[time.Time]() {
+			return v.Interface().(time.Time).IsZero()
 		}
+		if _, isOption := v.Type().MethodByName("AsPointer"); isOption {
+			type isZeroer interface{ IsZero() bool }
+			return v.Interface().(isZeroer).IsZero()
+		}
+		panic("structs other than time.Time and option.Option[T] are not supported")
 	}
 
-	switch v.Kind() {
-	case reflect.Func:
-		panic("functions are not supported")
-	case reflect.Struct:
-		panic("for structs only implementers of isZeroer are supported")
-	default:
-		return v.IsZero()
-	}
+	return v.IsZero()
 }

--- a/opts/serialize.go
+++ b/opts/serialize.go
@@ -61,6 +61,7 @@ func BuildQueryString(opts any) (url.Values, error) {
 		fieldValue reflect.Value
 		value      string
 	}
+	isRegularQueryField := make(map[string]bool) // tracks fields that are not value-discriminant field (for checking field name collisions)
 	valueDiscriminantFields := make(map[string][]valueField)
 
 	for _, field := range reflect.VisibleFields(optsType) {
@@ -85,6 +86,9 @@ func BuildQueryString(opts any) (url.Values, error) {
 
 		// value-discriminant fields: collect and skip normal processing
 		if value, ok := maybeValue.Unpack(); ok {
+			if isRegularQueryField[key] {
+				panic(fmt.Sprintf(`key %q cannot be declared as both a regular field and a value-discriminant field`, key))
+			}
 			if fieldValue.Kind() != reflect.Bool {
 				panic(fmt.Sprintf(`field %q has "value:" option but is not a bool`, field.Name))
 			}
@@ -93,6 +97,12 @@ func BuildQueryString(opts any) (url.Values, error) {
 				value:      value,
 			})
 			continue
+		}
+
+		// check collision between normal and value-discriminant fields
+		isRegularQueryField[key] = true
+		if _, exists := valueDiscriminantFields[key]; exists {
+			panic(fmt.Sprintf(`key %q cannot be declared as both a regular field and a value-discriminant field`, key))
 		}
 
 		// if field not set, skip

--- a/opts/serialize.go
+++ b/opts/serialize.go
@@ -26,26 +26,27 @@ import (
 //	}
 //	instance := Something{
 //	   Bar: "AAA",
-//	   Baz: "BBB",
+//	   Baz: 1,
 //	}
 //
 // will be converted into
 //
-//	?x_bar=AAA&lorem_ipsum=BBB
+//	?x_bar=AAA&lorem_ipsum=1
 //
 // On configuration errors (e.g. non-struct opts, opts with non-q-tagged fields)
 // the function panics. On user errors (e.g. missing required field) an error
 // is returned. On success, url.Values are returned according to the opts.
 //
-// This function understands and expects the same values for the "q" tag as [BuildQueryString].
+// This function understands and expects the same values for the "q" tag as [opts.ParseQueryString].
 // See documentation over there for details.
 //
 // [gophercloud.BuildQueryString]: https://pkg.go.dev/github.com/gophercloud/gophercloud/v2#BuildQueryString
-//
-// [option.Option]: https://pkg.go.dev/go.xyrillian.de/gg/option#Option
 func BuildQueryString(opts any) (url.Values, error) {
 	optsValue := reflect.ValueOf(opts)
 	if optsValue.Kind() == reflect.Ptr { //nolint: govet // won't inline this...
+		if optsValue.IsNil() {
+			panic("opts is a nil pointer")
+		}
 		optsValue = optsValue.Elem()
 	}
 	optsType := optsValue.Type()

--- a/opts/serialize.go
+++ b/opts/serialize.go
@@ -11,6 +11,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	. "go.xyrillian.de/gg/option"
 )
 
 // BuildQueryString is a function to be used by request methods with opts structs.
@@ -65,18 +67,15 @@ func BuildQueryString(opts any) (url.Values, error) {
 		if qTag == "" {
 			panic(fmt.Sprintf(`expected %q to have a "q:"-tag`, field.Name))
 		}
-		key, timeFormat, required := parseQTag(qTag)
-		// all known formats are currently timeFormats
-		if _, ok := TimeFormats[timeFormat]; timeFormat != "" && timeFormat != UnixFormat && !ok {
-			panic(fmt.Sprintf("unsupported time format %q; accepted: %s", timeFormat, supportedHumanReadableFormats))
+		key, maybeTimeFormat, required := parseQTag(qTag)
+
+		// check if format is set when required
+		if typeNeedsTimeFormat(fieldValue.Type()) && maybeTimeFormat.IsNone() {
+			panic(fmt.Sprintf(`time format is missing for field %q`, field.Name))
 		}
 
 		// if field not set, skip
-		if isZero(fieldValue) {
-			if required {
-				// if the field is required, it can't have a zero-value
-				return url.Values{}, fmt.Errorf("required query parameter [%s] not set", field.Name)
-			}
+		if canBeSkipped(fieldValue, required) {
 			continue
 		}
 	loop:
@@ -84,53 +83,48 @@ func BuildQueryString(opts any) (url.Values, error) {
 		case reflect.Ptr: //nolint: govet // won't inline this...
 			fieldValue = fieldValue.Elem()
 			goto loop
-		case reflect.String:
-			params.Add(key, fieldValue.String())
-		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-			params.Add(key, strconv.FormatInt(fieldValue.Int(), 10))
-		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-			params.Add(key, strconv.FormatUint(fieldValue.Uint(), 10))
-		case reflect.Bool:
-			params.Add(key, strconv.FormatBool(fieldValue.Bool()))
-		case reflect.Float32, reflect.Float64:
-			params.Add(key, strconv.FormatFloat(fieldValue.Float(), 'g', -1, fieldValue.Type().Bits()))
+		// only handle non-single-values here, rest is done by serializeSingleValue()
 		case reflect.Slice:
 			values := make([]string, fieldValue.Len())
 			for i := range fieldValue.Len() {
-				values[i] = serializeValue(fieldValue.Index(i), timeFormat)
+				values[i] = serializeSingleValue(fieldValue.Index(i), maybeTimeFormat)
 			}
 			params[key] = append(params[key], values...)
 		case reflect.Struct:
 			if fieldValue.Type() == reflect.TypeFor[time.Time]() {
-				if timeFormat == "" {
-					panic("time format is missing")
-				}
-				params.Add(key, serializeValue(fieldValue, timeFormat))
+				params.Add(key, serializeSingleValue(fieldValue, maybeTimeFormat))
 			} else if m := fieldValue.MethodByName("AsPointer"); m.IsValid() {
 				// Option[T] — unwrap via AsPointer
 				results := m.Call(nil)
 				if len(results) == 1 && results[0].Kind() == reflect.Ptr && !results[0].IsNil() { //nolint:govet // won't inline this...
-					params.Add(key, serializeValue(results[0].Elem(), timeFormat))
+					params.Add(key, serializeSingleValue(results[0].Elem(), maybeTimeFormat))
 				}
 			} else {
-				// defense in depth: already handled by isZero function
-				panic("for structs only time.Time and implementers of isZeroer are supported")
+				// defense in depth: already handled by canBeSkipped function
+				panic("for structs only implementers of isZeroer are supported")
 			}
 		case reflect.Map:
 			keys := fieldValue.MapKeys()
 			slices.SortFunc(keys, func(a, b reflect.Value) int {
-				return strings.Compare(serializeValue(a, ""), serializeValue(b, ""))
+				return strings.Compare(serializeSingleValue(a, maybeTimeFormat), serializeSingleValue(b, maybeTimeFormat))
 			})
 			for _, k := range keys {
-				params.Add(key, serializeValue(k, "")+":"+serializeValue(fieldValue.MapIndex(k), ""))
+				params.Add(key, serializeSingleValue(k, maybeTimeFormat)+":"+serializeSingleValue(fieldValue.MapIndex(k), maybeTimeFormat))
 			}
+		default:
+			params.Add(key, serializeSingleValue(fieldValue, maybeTimeFormat))
+		}
+		if required && isOnlyEmptyStrings(params[key]) {
+			// if the field is required, it cannot have no value (handles nil maps, slices, arrays)
+			return url.Values{}, fmt.Errorf("required query parameter [%s] not set", field.Name)
 		}
 	}
 	return params, nil
 }
 
-// serializeValue converts a reflect.Value to its string representation for query parameters.
-func serializeValue(v reflect.Value, timeFormat string) string {
+// serializeSingleValue converts a reflect.Value to its string representation for query parameters.
+// Zero values are skipped.
+func serializeSingleValue(v reflect.Value, timeFormat Option[string]) string {
 	// Dereference pointers.
 	for v.Kind() == reflect.Ptr { //nolint:govet // won't inline this...
 		v = v.Elem()
@@ -147,27 +141,62 @@ func serializeValue(v reflect.Value, timeFormat string) string {
 	case reflect.Float32, reflect.Float64:
 		return strconv.FormatFloat(v.Float(), 'g', -1, v.Type().Bits())
 	case reflect.Struct:
+		// handle time
 		if v.Type() == reflect.TypeFor[time.Time]() {
 			t := v.Interface().(time.Time)
-			switch timeFormat {
-			case UnixFormat:
+			tf := timeFormat.UnwrapOrPanic("timeFormat should have been set")
+			switch tf {
+			case unixTimeFormat:
 				return strconv.FormatInt(t.Unix(), 10)
 			default:
-				tf, exists := TimeFormats[timeFormat]
-				// defense in depth: should be checked outside of this function (when no value is set)
-				if !exists {
-					panic("unknown time format " + timeFormat)
-				}
-				return t.Format(tf)
+				layout := nonUnixTimeFormats[tf]
+				return t.Format(layout)
 			}
 		}
-		// For Option[T] and similar wrapper types: try to unwrap via AsPointer() method.
+		// handle Option[T]: try to unwrap via AsPointer() method.
 		if m := v.MethodByName("AsPointer"); m.IsValid() {
 			results := m.Call(nil)
 			if len(results) == 1 && results[0].Kind() == reflect.Ptr && !results[0].IsNil() { //nolint:govet // won't inline this...
-				return serializeValue(results[0].Elem(), timeFormat)
+				return serializeSingleValue(results[0].Elem(), timeFormat)
 			}
 		}
 	}
 	return fmt.Sprintf("%v", v.Interface())
+}
+
+// canBeSkipped checks if a value can be skipped for serialization into a query string.
+// Required params are never skipped. Otherwise, isZero() of the value is checked.
+// Special handling is applied to
+// - structs (check isZero() interface)
+// - slices, arrays, maps (considered zero when nil or all values are zero)
+func canBeSkipped(v reflect.Value, required bool) bool {
+	if required {
+		return false
+	}
+	// check pointers
+	if v.Kind() == reflect.Ptr { //nolint:govet // won't inline this...
+		if v.IsNil() {
+			// Guard against nil pointers whose element type has pointer-receiver IsZero.
+			return true
+		}
+		// Dereference the pointer and check the element.
+		return canBeSkipped(v.Elem(), false)
+	}
+
+	// check for types implementing IsZero() bool (e.g. Option[T], time.Time).
+	if v.CanInterface() {
+		type isZeroer interface{ IsZero() bool }
+		if z, ok := v.Interface().(isZeroer); ok {
+			return z.IsZero()
+		}
+	}
+
+	switch v.Kind() {
+	case reflect.Func:
+		panic("functions are not supported")
+	case reflect.Struct:
+		panic("for structs only implementers of isZeroer are supported")
+	default:
+		return v.IsZero()
+	}
 }

--- a/opts/serialize.go
+++ b/opts/serialize.go
@@ -1,0 +1,203 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package opts
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"reflect"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+)
+
+/*
+BuildQueryString is an internal function to be used by request methods in
+individual resource packages.
+
+It accepts a tagged structure and expands it into a URL struct. Field names are
+converted into query parameters based on a "q" tag. For example:
+
+	type struct Something {
+	   Bar string `q:"x_bar"`
+	   Baz int    `q:"lorem_ipsum"`
+	}
+	instance := Something{
+	   Bar: "AAA",
+	   Baz: "BBB",
+	}
+
+will be converted into "?x_bar=AAA&lorem_ipsum=BBB".
+
+The struct's fields may be strings, integers, slices, or boolean values. Fields
+left at their type's zero value will be omitted from the query.
+
+Slice are handled in one of two ways:
+
+	type struct Something {
+	   Bar []string `q:"bar"` // E.g. ?bar=1&bar=2
+	   Baz []int    `q:"baz" format="comma-separated"` // E.g. ?baz=1,2
+	}
+*/
+func BuildQueryString(opts any) (*url.URL, error) {
+	optsValue := reflect.ValueOf(opts)
+	if optsValue.Kind() == reflect.Ptr { //nolint: govet // won't inline this...
+		optsValue = optsValue.Elem()
+	}
+
+	optsType := reflect.TypeOf(opts)
+	if optsType.Kind() == reflect.Ptr { //nolint: govet // won't inline this...
+		optsType = optsType.Elem()
+	}
+
+	params := url.Values{}
+
+	if optsValue.Kind() == reflect.Struct {
+		for i := range optsValue.NumField() {
+			v := optsValue.Field(i)
+			f := optsType.Field(i)
+			qTag := f.Tag.Get("q")
+
+			// if the field has a 'q' tag, it goes in the query string
+			if qTag != "" {
+				tags := strings.Split(qTag, ",")
+
+				// if the field is set, add it to the slice of query pieces
+				if !isZero(v) {
+					format := f.Tag.Get("format")
+				loop:
+					switch v.Kind() {
+					case reflect.Ptr: //nolint: govet // won't inline this...
+						v = v.Elem()
+						goto loop
+					case reflect.String:
+						params.Add(tags[0], v.String())
+					case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+						params.Add(tags[0], strconv.FormatInt(v.Int(), 10))
+					case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+						params.Add(tags[0], strconv.FormatUint(v.Uint(), 10))
+					case reflect.Bool:
+						params.Add(tags[0], strconv.FormatBool(v.Bool()))
+					case reflect.Float32, reflect.Float64:
+						params.Add(tags[0], strconv.FormatFloat(v.Float(), 'g', -1, v.Type().Bits()))
+					case reflect.Slice:
+						var values []string
+						for i := range v.Len() {
+							values = append(values, serializeValue(v.Index(i), format))
+						}
+						if format == "comma-separated" {
+							params.Add(tags[0], strings.Join(values, ","))
+						} else {
+							params[tags[0]] = append(params[tags[0]], values...)
+						}
+					case reflect.Struct:
+						if v.Type() == reflect.TypeFor[time.Time]() {
+							params.Add(tags[0], serializeValue(v, format))
+						} else if m := v.MethodByName("AsPointer"); m.IsValid() {
+							// Option[T] — unwrap via AsPointer
+							results := m.Call(nil)
+							if len(results) == 1 && results[0].Kind() == reflect.Ptr && !results[0].IsNil() { //nolint:govet // won't inline this...
+								params.Add(tags[0], serializeValue(results[0].Elem(), format))
+							}
+						} else {
+							// Plain nested struct — serialize with dot-prefix
+							serializeStruct(v, tags[0], params)
+						}
+					case reflect.Map:
+						if v.Type().Key().Kind() == reflect.String && v.Type().Elem().Kind() == reflect.String {
+							keys := make([]string, 0, v.Len())
+							for _, k := range v.MapKeys() {
+								keys = append(keys, k.String())
+							}
+							slices.Sort(keys)
+							var s []string
+							for _, k := range keys {
+								value := v.MapIndex(reflect.ValueOf(k)).String()
+								s = append(s, fmt.Sprintf("'%s':'%s'", k, value))
+							}
+							params.Add(tags[0], fmt.Sprintf("{%s}", strings.Join(s, ", ")))
+						}
+					}
+				} else {
+					// if the field has a 'required' tag, it can't have a zero-value
+					if requiredTag := f.Tag.Get("required"); requiredTag == "true" {
+						return &url.URL{}, fmt.Errorf("required query parameter [%s] not set", f.Name)
+					}
+				}
+			}
+		}
+
+		return &url.URL{RawQuery: params.Encode()}, nil
+	}
+	// Return an error if the underlying type of 'opts' isn't a struct.
+	return nil, errors.New("options type is not a struct")
+}
+
+// serializeStruct serializes a struct's q-tagged fields as dot-prefixed query parameters.
+func serializeStruct(v reflect.Value, prefix string, params url.Values) {
+	vType := v.Type()
+	for i := range v.NumField() {
+		fv := v.Field(i)
+		f := vType.Field(i)
+		qTag := f.Tag.Get("q")
+		if qTag == "" {
+			continue
+		}
+		key := prefix + "." + strings.SplitN(qTag, ",", 2)[0]
+		if !isZero(fv) {
+			format := f.Tag.Get("format")
+			// Dereference pointer
+			for fv.Kind() == reflect.Ptr { //nolint:govet // won't inline this...
+				fv = fv.Elem()
+			}
+			params.Add(key, serializeValue(fv, format))
+		}
+	}
+}
+
+// serializeValue converts a reflect.Value to its string representation for query parameters.
+func serializeValue(v reflect.Value, format string) string {
+	// Dereference pointers.
+	for v.Kind() == reflect.Ptr { //nolint:govet // won't inline this...
+		v = v.Elem()
+	}
+	switch v.Kind() {
+	case reflect.String:
+		return v.String()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return strconv.FormatInt(v.Int(), 10)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return strconv.FormatUint(v.Uint(), 10)
+	case reflect.Bool:
+		return strconv.FormatBool(v.Bool())
+	case reflect.Float32, reflect.Float64:
+		return strconv.FormatFloat(v.Float(), 'g', -1, v.Type().Bits())
+	case reflect.Struct:
+		if v.Type() == reflect.TypeFor[time.Time]() {
+			t := v.Interface().(time.Time)
+			switch format {
+			case "":
+				return t.Format(time.RFC3339)
+			case unixFormat:
+				return strconv.FormatInt(t.Unix(), 10)
+			default:
+				tf, exists := timeFormats[format]
+				if !exists {
+					panic("unknown time format " + format)
+				}
+				return t.Format(tf)
+			}
+		}
+		// For Option[T] and similar wrapper types: try to unwrap via AsPointer() method.
+		if m := v.MethodByName("AsPointer"); m.IsValid() {
+			results := m.Call(nil)
+			if len(results) == 1 && results[0].Kind() == reflect.Ptr && !results[0].IsNil() { //nolint:govet // won't inline this...
+				return serializeValue(results[0].Elem(), format)
+			}
+		}
+	}
+	return fmt.Sprintf("%v", v.Interface())
+}

--- a/opts/serialize.go
+++ b/opts/serialize.go
@@ -4,158 +4,129 @@
 package opts
 
 import (
-	"errors"
 	"fmt"
 	"net/url"
 	"reflect"
 	"slices"
 	"strconv"
-	"strings"
 	"time"
 )
 
-/*
-BuildQueryString is an internal function to be used by request methods in
-individual resource packages.
-
-It accepts a tagged structure and expands it into a URL struct. Field names are
-converted into query parameters based on a "q" tag. For example:
-
-	type struct Something {
-	   Bar string `q:"x_bar"`
-	   Baz int    `q:"lorem_ipsum"`
-	}
-	instance := Something{
-	   Bar: "AAA",
-	   Baz: "BBB",
-	}
-
-will be converted into "?x_bar=AAA&lorem_ipsum=BBB".
-
-The struct's fields may be strings, integers, slices, or boolean values. Fields
-left at their type's zero value will be omitted from the query.
-
-Slice are handled in one of two ways:
-
-	type struct Something {
-	   Bar []string `q:"bar"` // E.g. ?bar=1&bar=2
-	   Baz []int    `q:"baz" format="comma-separated"` // E.g. ?baz=1,2
-	}
-*/
-func BuildQueryString(opts any) (*url.URL, error) {
+// BuildQueryString is a function to be used by request methods with opts structs.
+// It's inspired by gophercloud.BuildQueryString with partially stricter behavior.
+// It accepts a tagged structure and expands it into a URL struct. Field names are
+// converted into query parameters based on a "q" tag. For example:
+//
+//	type struct Something {
+//	   Bar string `q:"x_bar"`
+//	   Baz int    `q:"lorem_ipsum"`
+//	}
+//	instance := Something{
+//	   Bar: "AAA",
+//	   Baz: "BBB",
+//	}
+//
+// will be converted into "?x_bar=AAA&lorem_ipsum=BBB".
+//
+// On configuration errors (e.g. non-struct opts, opts with non-q-tagged fields)
+// the function panics. On user errors (e.g. missing required field) an error
+// is returned. On success, url.Values are returned according to the opts.
+//
+// The serialization supports all scalars except complex. Structs of scalars are supported
+// and special structs like time.Time. Additionally, it allows Slices (for multiple
+// values), option.Option (recommended for optional values) and pointers (as alternative
+// to option.Option) of these. Only map[string]string is supported as a map type.
+// Fields left at their type's zero value will be omitted from the query.
+//
+// Slice fields use repeated query parameters:
+// Foo []string `q:"foo"`                       // ?foo=a&foo=b
+//
+// Map fields accept plain repeated key:value pairs:
+// Bar map[string]string `q:"bar"`              // ?bar=k1:v1&bar=k2:v2
+//
+// time.Time fields support the formats RFC3339Nano, RFC3339, DateTime, Date, Unix.
+// A single `format` option can be set, to define what is used for serialization, otherwise
+// the default RFC3339 gets used:
+// Baz time.Time `q:"baz,format:DateTime"`       // ?baz=1999-01-01 00:00:00
+//
+// A `required` option can be set to define that a missing value will produce an error.
+// Quux string `q:"quux,required"`               // ?foo=bar --> error
+func BuildQueryString(opts any) (url.Values, error) {
 	optsValue := reflect.ValueOf(opts)
 	if optsValue.Kind() == reflect.Ptr { //nolint: govet // won't inline this...
 		optsValue = optsValue.Elem()
 	}
-
-	optsType := reflect.TypeOf(opts)
-	if optsType.Kind() == reflect.Ptr { //nolint: govet // won't inline this...
-		optsType = optsType.Elem()
-	}
-
+	optsType := optsValue.Type()
 	params := url.Values{}
 
-	if optsValue.Kind() == reflect.Struct {
-		for i := range optsValue.NumField() {
-			v := optsValue.Field(i)
-			f := optsType.Field(i)
-			qTag := f.Tag.Get("q")
+	if optsValue.Kind() != reflect.Struct {
+		panic("options type is not a struct")
+	}
+	for _, field := range reflect.VisibleFields(optsType) {
+		fieldValue := optsValue.FieldByIndex(field.Index)
+		qTag := field.Tag.Get("q")
+		if qTag == "" {
+			panic(fmt.Sprintf(`expected %q to have a "q:"-tag`, field.Name))
+		}
+		key, format, required := parseQTag(qTag)
 
-			// if the field has a 'q' tag, it goes in the query string
-			if qTag != "" {
-				tags := strings.Split(qTag, ",")
-
-				// if the field is set, add it to the slice of query pieces
-				if !isZero(v) {
-					format := f.Tag.Get("format")
-				loop:
-					switch v.Kind() {
-					case reflect.Ptr: //nolint: govet // won't inline this...
-						v = v.Elem()
-						goto loop
-					case reflect.String:
-						params.Add(tags[0], v.String())
-					case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-						params.Add(tags[0], strconv.FormatInt(v.Int(), 10))
-					case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-						params.Add(tags[0], strconv.FormatUint(v.Uint(), 10))
-					case reflect.Bool:
-						params.Add(tags[0], strconv.FormatBool(v.Bool()))
-					case reflect.Float32, reflect.Float64:
-						params.Add(tags[0], strconv.FormatFloat(v.Float(), 'g', -1, v.Type().Bits()))
-					case reflect.Slice:
-						var values []string
-						for i := range v.Len() {
-							values = append(values, serializeValue(v.Index(i), format))
-						}
-						if format == "comma-separated" {
-							params.Add(tags[0], strings.Join(values, ","))
-						} else {
-							params[tags[0]] = append(params[tags[0]], values...)
-						}
-					case reflect.Struct:
-						if v.Type() == reflect.TypeFor[time.Time]() {
-							params.Add(tags[0], serializeValue(v, format))
-						} else if m := v.MethodByName("AsPointer"); m.IsValid() {
-							// Option[T] — unwrap via AsPointer
-							results := m.Call(nil)
-							if len(results) == 1 && results[0].Kind() == reflect.Ptr && !results[0].IsNil() { //nolint:govet // won't inline this...
-								params.Add(tags[0], serializeValue(results[0].Elem(), format))
-							}
-						} else {
-							// Plain nested struct — serialize with dot-prefix
-							serializeStruct(v, tags[0], params)
-						}
-					case reflect.Map:
-						if v.Type().Key().Kind() == reflect.String && v.Type().Elem().Kind() == reflect.String {
-							keys := make([]string, 0, v.Len())
-							for _, k := range v.MapKeys() {
-								keys = append(keys, k.String())
-							}
-							slices.Sort(keys)
-							var s []string
-							for _, k := range keys {
-								value := v.MapIndex(reflect.ValueOf(k)).String()
-								s = append(s, fmt.Sprintf("'%s':'%s'", k, value))
-							}
-							params.Add(tags[0], fmt.Sprintf("{%s}", strings.Join(s, ", ")))
-						}
-					}
-				} else {
-					// if the field has a 'required' tag, it can't have a zero-value
-					if requiredTag := f.Tag.Get("required"); requiredTag == "true" {
-						return &url.URL{}, fmt.Errorf("required query parameter [%s] not set", f.Name)
-					}
+		// if field not set, skip
+		if isZero(fieldValue) {
+			if required {
+				// if the field is required, it can't have a zero-value
+				return url.Values{}, fmt.Errorf("required query parameter [%s] not set", field.Name)
+			}
+			continue
+		}
+	loop:
+		switch fieldValue.Kind() {
+		case reflect.Ptr: //nolint: govet // won't inline this...
+			fieldValue = fieldValue.Elem()
+			goto loop
+		case reflect.String:
+			params.Add(key, fieldValue.String())
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			params.Add(key, strconv.FormatInt(fieldValue.Int(), 10))
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			params.Add(key, strconv.FormatUint(fieldValue.Uint(), 10))
+		case reflect.Bool:
+			params.Add(key, strconv.FormatBool(fieldValue.Bool()))
+		case reflect.Float32, reflect.Float64:
+			params.Add(key, strconv.FormatFloat(fieldValue.Float(), 'g', -1, fieldValue.Type().Bits()))
+		case reflect.Slice:
+			var values []string
+			for i := range fieldValue.Len() {
+				values = append(values, serializeValue(fieldValue.Index(i), format))
+			}
+			params[key] = append(params[key], values...)
+		case reflect.Struct:
+			if fieldValue.Type() == reflect.TypeFor[time.Time]() {
+				params.Add(key, serializeValue(fieldValue, format))
+			} else if m := fieldValue.MethodByName("AsPointer"); m.IsValid() {
+				// Option[T] — unwrap via AsPointer
+				results := m.Call(nil)
+				if len(results) == 1 && results[0].Kind() == reflect.Ptr && !results[0].IsNil() { //nolint:govet // won't inline this...
+					params.Add(key, serializeValue(results[0].Elem(), format))
+				}
+			} else {
+				// defense in depth: already handled by isZero function
+				panic("for structs only time.Time and implementers of isZeroer are supported")
+			}
+		case reflect.Map:
+			if fieldValue.Type().Key().Kind() == reflect.String && fieldValue.Type().Elem().Kind() == reflect.String {
+				keys := make([]string, 0, fieldValue.Len())
+				for _, k := range fieldValue.MapKeys() {
+					keys = append(keys, k.String())
+				}
+				slices.Sort(keys)
+				for _, k := range keys {
+					value := fieldValue.MapIndex(reflect.ValueOf(k)).String()
+					params.Add(key, k+":"+value)
 				}
 			}
 		}
-
-		return &url.URL{RawQuery: params.Encode()}, nil
 	}
-	// Return an error if the underlying type of 'opts' isn't a struct.
-	return nil, errors.New("options type is not a struct")
-}
-
-// serializeStruct serializes a struct's q-tagged fields as dot-prefixed query parameters.
-func serializeStruct(v reflect.Value, prefix string, params url.Values) {
-	vType := v.Type()
-	for i := range v.NumField() {
-		fv := v.Field(i)
-		f := vType.Field(i)
-		qTag := f.Tag.Get("q")
-		if qTag == "" {
-			continue
-		}
-		key := prefix + "." + strings.SplitN(qTag, ",", 2)[0]
-		if !isZero(fv) {
-			format := f.Tag.Get("format")
-			// Dereference pointer
-			for fv.Kind() == reflect.Ptr { //nolint:govet // won't inline this...
-				fv = fv.Elem()
-			}
-			params.Add(key, serializeValue(fv, format))
-		}
-	}
+	return params, nil
 }
 
 // serializeValue converts a reflect.Value to its string representation for query parameters.

--- a/opts/serialize_test.go
+++ b/opts/serialize_test.go
@@ -171,6 +171,11 @@ func checkSerializingPanic(t *testing.T, panicMsg string, fn func()) {
 }
 
 func TestBuildQueryStringErrors(t *testing.T) {
+	// nil-pointer input (panics)
+	checkSerializingPanic(t, "opts is a nil pointer", func() {
+		opts.BuildQueryString((*testOpts)(nil)) //nolint:errcheck // won't get to this part
+	})
+
 	// non-struct input (panics)
 	checkSerializingPanic(t, "options type is not a struct", func() {
 		opts.BuildQueryString(42) //nolint:errcheck // won't get to this part
@@ -213,7 +218,7 @@ func TestBuildQueryStringErrors(t *testing.T) {
 	type testMissingTimeFormatOpts struct {
 		Time time.Time `q:"time"`
 	}
-	checkParsingPanic(t, `time format is missing for field "Time"`, func() {
+	checkSerializingPanic(t, `time format is missing for field "Time"`, func() {
 		opts.BuildQueryString(testMissingTimeFormatOpts{}) //nolint:errcheck // won't get to this part
 	})
 

--- a/opts/serialize_test.go
+++ b/opts/serialize_test.go
@@ -202,6 +202,26 @@ func TestBuildQueryStringErrors(t *testing.T) {
 		opts.BuildQueryString(testEmbeddedQTagOpts{}) //nolint:errcheck // won't get to this part
 	})
 
+	// contradictory field declarations
+	type testFieldNameCollisionOpts struct {
+		Scope   string   `q:"scope"`
+		With    []string `q:"with"`
+		WithFoo bool     `q:"with,value:foo"`
+		WithBar bool     `q:"with,value:bar"`
+	}
+	checkParsingPanic(t, `key "with" cannot be declared as both a regular field and a value-discriminant field`, func() {
+		opts.BuildQueryString(testFieldNameCollisionOpts{}) //nolint:errcheck // won't get to this part
+	})
+	type testFieldNameCollisionOptsFlipped struct {
+		Scope   string   `q:"scope"`
+		WithFoo bool     `q:"with,value:foo"`
+		WithBar bool     `q:"with,value:bar"`
+		With    []string `q:"with"`
+	}
+	checkParsingPanic(t, `key "with" cannot be declared as both a regular field and a value-discriminant field`, func() {
+		opts.BuildQueryString(testFieldNameCollisionOptsFlipped{}) //nolint:errcheck // won't get to this part
+	})
+
 	// unknown struct parameter (panics)
 	type testNested struct {
 		String string `q:"string"`

--- a/opts/serialize_test.go
+++ b/opts/serialize_test.go
@@ -22,11 +22,11 @@ func checkSerializingHappyPath(t *testing.T, variable string, input any, expecte
 				t.Fatalf("panic: %v", r)
 			}
 		}()
-		u, err := opts.BuildQueryString(input)
+		v, err := opts.BuildQueryString(input)
 		if err != nil {
 			t.Fatal(variable + ": " + err.Error())
 		}
-		th.CheckEquals(t, expectedQuery, u.RawQuery)
+		th.CheckEquals(t, expectedQuery, v.Encode())
 	})
 }
 
@@ -34,23 +34,15 @@ func TestBuildQueryStringHappyPaths(t *testing.T) {
 	// empty struct (all zero values omitted)
 	checkSerializingHappyPath(t, "empty", testOpts{}, "")
 
-	// map OpenStack brace notation
-	checkSerializingHappyPath(t, "string_map", testOpts{StringMap: map[string]string{"k1": "v1", "k2": "v2"}}, "string_map=%7B%27k1%27%3A%27v1%27%2C+%27k2%27%3A%27v2%27%7D")
-
-	// struct
-	checkSerializingHappyPath(t, "struct",
-		testOpts{Struct: testInnerOpts{Name: "foo", Age: 42}},
-		"struct.age=42&struct.name=foo")
-
-	// bool
-	checkSerializingHappyPath(t, "bool", testOpts{Bool: true}, "bool=true")
+	// map
+	checkSerializingHappyPath(t, "string_map", testOpts{StringMap: map[string]string{"k1": "v1", "k2": "v2"}}, "string_map=k1%3Av1&string_map=k2%3Av2")
 
 	// time
 	checkSerializingHappyPath(t, "time",
 		testOpts{Time: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)},
 		"time=2000-01-01T00%3A00%3A00Z")
 	type testTimeRFCNanoOpts struct {
-		Time time.Time `q:"time" format:"RFC3339Nano"`
+		Time time.Time `q:"time,format:RFC3339Nano"`
 	}
 	checkSerializingHappyPath(t, "time RFC3339Nano", testTimeRFCNanoOpts{Time: time.Date(2000, 1, 1, 0, 0, 0, 1, time.UTC)}, "time=2000-01-01T00%3A00%3A00.000000001Z")
 	loc, err := time.LoadLocation("Europe/Berlin")
@@ -59,23 +51,24 @@ func TestBuildQueryStringHappyPaths(t *testing.T) {
 	}
 	checkSerializingHappyPath(t, "time RFC3339Nano", testTimeRFCNanoOpts{Time: time.Date(2000, 1, 1, 0, 0, 0, 1, loc)}, "time=2000-01-01T00%3A00%3A00.000000001%2B01%3A00")
 	type testTimeRFCOpts struct {
-		Time time.Time `q:"time" format:"RFC3339"`
+		Time time.Time `q:"time,format:RFC3339"`
 	}
 	checkSerializingHappyPath(t, "time RFC3339", testTimeRFCOpts{Time: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)}, "time=2000-01-01T00%3A00%3A00Z")
 	type testTimeDateTimeOpts struct {
-		Time time.Time `q:"time" format:"DateTime"`
+		Time time.Time `q:"time,format:DateTime"`
 	}
 	checkSerializingHappyPath(t, "time DateTime", testTimeDateTimeOpts{Time: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)}, "time=2000-01-01+00%3A00%3A00")
 	type testTimeDateOpts struct {
-		Time time.Time `q:"time" format:"DateOnly"`
+		Time time.Time `q:"time,format:DateOnly"`
 	}
 	checkSerializingHappyPath(t, "time Date", testTimeDateOpts{Time: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)}, "time=2000-01-01")
 	type testTimeUnixOpts struct {
-		Time time.Time `q:"time" format:"Unix"`
+		Time time.Time `q:"time,format:Unix"`
 	}
 	checkSerializingHappyPath(t, "time Date", testTimeUnixOpts{Time: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)}, "time=946684800")
 
 	// plain scalars
+	checkSerializingHappyPath(t, "bool", testOpts{Bool: true}, "bool=true")
 	checkSerializingHappyPath(t, "string", testOpts{String: "hello"}, "string=hello")
 	checkSerializingHappyPath(t, "int", testOpts{Int: -42}, "int=-42")
 	checkSerializingHappyPath(t, "int8", testOpts{Int8: -8}, "int8=-8")
@@ -91,9 +84,6 @@ func TestBuildQueryStringHappyPaths(t *testing.T) {
 	checkSerializingHappyPath(t, "float64", testOpts{Float64: -2.5}, "float64=-2.5")
 
 	// pointers
-	checkSerializingHappyPath(t, "pointer_struct",
-		testOpts{PointerStruct: &testInnerOpts{Name: "bar", Age: 7}},
-		"pointer_struct.age=7&pointer_struct.name=bar")
 	checkSerializingHappyPath(t, "pointer_bool", testOpts{PointerBool: new(true)}, "pointer_bool=true")
 	checkSerializingHappyPath(t, "pointer_time", testOpts{PointerTime: new(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC))}, "pointer_time=2000-01-01T00%3A00%3A00Z")
 	checkSerializingHappyPath(t, "pointer_string", testOpts{PointerString: new("world")}, "pointer_string=world")
@@ -132,12 +122,6 @@ func TestBuildQueryStringHappyPaths(t *testing.T) {
 	checkSerializingHappyPath(t, "float32_slice", testOpts{Float32Slice: []float32{1.5, 2.5}}, "float32_slice=1.5&float32_slice=2.5")
 	checkSerializingHappyPath(t, "float64_slice", testOpts{Float64Slice: []float64{1.5, 2.5}}, "float64_slice=1.5&float64_slice=2.5")
 
-	// slice comma-separated
-	type testSliceCommaSeparatedOpts struct {
-		StringSlice []string `q:"string_slice" format:"comma-separated"`
-	}
-	checkSerializingHappyPath(t, "string_slice comma-separated", testSliceCommaSeparatedOpts{StringSlice: []string{"a", "b", "c"}}, "string_slice=a%2Cb%2Cc")
-
 	// options
 	checkSerializingHappyPath(t, "option_bool", testOpts{OptionBool: Some(true)}, "option_bool=true")
 	checkSerializingHappyPath(t, "option_time",
@@ -163,15 +147,61 @@ func TestBuildQueryStringHappyPaths(t *testing.T) {
 		"bool=true&int=5&option_string=world&string=hi")
 }
 
-func TestBuildQueryStringErrors(t *testing.T) {
-	// non-struct input
-	_, err := opts.BuildQueryString(42)
-	th.AssertErr(t, "options type is not a struct", err)
+func checkSerializingPanic(t *testing.T, panicMsg string, fn func()) {
+	t.Helper()
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Errorf("expected panic %q, but function did not panic", panicMsg)
+		}
+		got, ok := r.(string)
+		if !ok {
+			t.Errorf("expected panic with string %q, but got non-string panic: %v", panicMsg, r)
+		}
+		if got != panicMsg {
+			t.Errorf("expected panic: %s, but got: %s", panicMsg, got)
+		}
+	}()
+	fn()
+}
 
-	// required field with zero value
-	type requiredOpts struct {
-		Name string `q:"name" required:"true"`
+func TestBuildQueryStringErrors(t *testing.T) {
+	// non-struct input (panics)
+	checkSerializingPanic(t, "options type is not a struct", func() {
+		opts.BuildQueryString(42) //nolint:errcheck // won't get to this part
+	})
+
+	// missing q-tag (panics)
+	type testNonOpts struct {
+		String string `yaml:"string"`
 	}
-	_, err = opts.BuildQueryString(requiredOpts{})
+	checkParsingPanic(t, `expected "String" to have a "q:"-tag`, func() {
+		opts.BuildQueryString(testNonOpts{}) //nolint:errcheck // won't get to this part
+	})
+
+	// unknown struct parameter (panics)
+	type testNested struct {
+		String string `q:"string"`
+	}
+	type testNested2 struct {
+		Nested testNested `q:"nested"`
+	}
+	checkParsingPanic(t, "for structs only time.Time and implementers of isZeroer are supported", func() {
+		opts.BuildQueryString(testNested2{}) //nolint:errcheck // won't get to this part
+	})
+
+	// unknown time format (panics)
+	type testBadTimeFormatOpts struct {
+		Time time.Time `q:"time,format:foo"`
+	}
+	checkSerializingPanic(t, "unknown time format foo", func() {
+		opts.BuildQueryString(testBadTimeFormatOpts{Time: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)}) //nolint:errcheck // won't get to this part
+	})
+
+	//  missing required parameter
+	type requiredOpts struct {
+		Name string `q:"name,required"`
+	}
+	_, err := opts.BuildQueryString(requiredOpts{})
 	th.AssertErr(t, "required query parameter [Name] not set", err)
 }

--- a/opts/serialize_test.go
+++ b/opts/serialize_test.go
@@ -209,7 +209,7 @@ func TestBuildQueryStringErrors(t *testing.T) {
 	type testNested2 struct {
 		Nested testNested `q:"nested"`
 	}
-	checkSerializingPanic(t, "for structs only implementers of isZeroer are supported", func() {
+	checkSerializingPanic(t, "structs other than time.Time and option.Option[T] are not supported", func() {
 		opts.BuildQueryString(testNested2{}) //nolint:errcheck // won't get to this part
 	})
 

--- a/opts/serialize_test.go
+++ b/opts/serialize_test.go
@@ -163,10 +163,12 @@ func checkSerializingPanic(t *testing.T, panicMsg string, fn func()) {
 		r := recover()
 		if r == nil {
 			t.Errorf("expected panic %q, but function did not panic", panicMsg)
+			return
 		}
 		got, ok := r.(string)
 		if !ok {
 			t.Errorf("expected panic with string %q, but got non-string panic: %v", panicMsg, r)
+			return
 		}
 		if got != panicMsg {
 			t.Errorf("expected panic: %s, but got: %s", panicMsg, got)

--- a/opts/serialize_test.go
+++ b/opts/serialize_test.go
@@ -150,6 +150,11 @@ func TestBuildQueryStringHappyPaths(t *testing.T) {
 	checkSerializingHappyPath(t, "multiple fields",
 		testOpts{Bool: true, String: "hi", Int: 5, OptionString: Some("world")},
 		"bool=true&int=5&option_string=world&string=hi")
+
+	// value-discriminant bools (2 set, 1 unset)
+	checkSerializingHappyPath(t, "value-discriminant bools",
+		testOpts{WithDetails: true, WithSubresources: false, WithSubcapacities: true},
+		"with=details&with=subcapacities")
 }
 
 func checkSerializingPanic(t *testing.T, panicMsg string, fn func()) {

--- a/opts/serialize_test.go
+++ b/opts/serialize_test.go
@@ -199,7 +199,7 @@ func TestBuildQueryStringErrors(t *testing.T) {
 	type testNested2 struct {
 		Nested testNested `q:"nested"`
 	}
-	checkSerializingPanic(t, "for structs only time.Time and implementers of isZeroer are supported", func() {
+	checkSerializingPanic(t, "for structs only implementers of isZeroer are supported", func() {
 		opts.BuildQueryString(testNested2{}) //nolint:errcheck // won't get to this part
 	})
 
@@ -208,7 +208,13 @@ func TestBuildQueryStringErrors(t *testing.T) {
 		Time time.Time `q:"time,format:foo"`
 	}
 	checkSerializingPanic(t, `unsupported time format "foo"; accepted: DateOnly, DateTime, RFC3339, RFC3339Nano, Unix`, func() {
-		opts.BuildQueryString(testBadTimeFormatOpts{Time: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)}) //nolint:errcheck // won't get to this part
+		opts.BuildQueryString(testBadTimeFormatOpts{}) //nolint:errcheck // won't get to this part
+	})
+	type testMissingTimeFormatOpts struct {
+		Time time.Time `q:"time"`
+	}
+	checkParsingPanic(t, `time format is missing for field "Time"`, func() {
+		opts.BuildQueryString(testMissingTimeFormatOpts{}) //nolint:errcheck // won't get to this part
 	})
 
 	//  missing required parameter

--- a/opts/serialize_test.go
+++ b/opts/serialize_test.go
@@ -1,0 +1,177 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package opts_test
+
+import (
+	"testing"
+	"time"
+
+	. "go.xyrillian.de/gg/option"
+
+	th "github.com/sapcc/go-api-declarations/internal/testhelper"
+	"github.com/sapcc/go-api-declarations/opts"
+)
+
+func checkSerializingHappyPath(t *testing.T, variable string, input any, expectedQuery string) {
+	t.Helper()
+	t.Run(variable, func(t *testing.T) {
+		t.Helper()
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("panic: %v", r)
+			}
+		}()
+		u, err := opts.BuildQueryString(input)
+		if err != nil {
+			t.Fatal(variable + ": " + err.Error())
+		}
+		th.CheckEquals(t, expectedQuery, u.RawQuery)
+	})
+}
+
+func TestBuildQueryStringHappyPaths(t *testing.T) {
+	// empty struct (all zero values omitted)
+	checkSerializingHappyPath(t, "empty", testOpts{}, "")
+
+	// map OpenStack brace notation
+	checkSerializingHappyPath(t, "string_map", testOpts{StringMap: map[string]string{"k1": "v1", "k2": "v2"}}, "string_map=%7B%27k1%27%3A%27v1%27%2C+%27k2%27%3A%27v2%27%7D")
+
+	// struct
+	checkSerializingHappyPath(t, "struct",
+		testOpts{Struct: testInnerOpts{Name: "foo", Age: 42}},
+		"struct.age=42&struct.name=foo")
+
+	// bool
+	checkSerializingHappyPath(t, "bool", testOpts{Bool: true}, "bool=true")
+
+	// time
+	checkSerializingHappyPath(t, "time",
+		testOpts{Time: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)},
+		"time=2000-01-01T00%3A00%3A00Z")
+	type testTimeRFCNanoOpts struct {
+		Time time.Time `q:"time" format:"RFC3339Nano"`
+	}
+	checkSerializingHappyPath(t, "time RFC3339Nano", testTimeRFCNanoOpts{Time: time.Date(2000, 1, 1, 0, 0, 0, 1, time.UTC)}, "time=2000-01-01T00%3A00%3A00.000000001Z")
+	loc, err := time.LoadLocation("Europe/Berlin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkSerializingHappyPath(t, "time RFC3339Nano", testTimeRFCNanoOpts{Time: time.Date(2000, 1, 1, 0, 0, 0, 1, loc)}, "time=2000-01-01T00%3A00%3A00.000000001%2B01%3A00")
+	type testTimeRFCOpts struct {
+		Time time.Time `q:"time" format:"RFC3339"`
+	}
+	checkSerializingHappyPath(t, "time RFC3339", testTimeRFCOpts{Time: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)}, "time=2000-01-01T00%3A00%3A00Z")
+	type testTimeDateTimeOpts struct {
+		Time time.Time `q:"time" format:"DateTime"`
+	}
+	checkSerializingHappyPath(t, "time DateTime", testTimeDateTimeOpts{Time: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)}, "time=2000-01-01+00%3A00%3A00")
+	type testTimeDateOpts struct {
+		Time time.Time `q:"time" format:"DateOnly"`
+	}
+	checkSerializingHappyPath(t, "time Date", testTimeDateOpts{Time: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)}, "time=2000-01-01")
+	type testTimeUnixOpts struct {
+		Time time.Time `q:"time" format:"Unix"`
+	}
+	checkSerializingHappyPath(t, "time Date", testTimeUnixOpts{Time: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)}, "time=946684800")
+
+	// plain scalars
+	checkSerializingHappyPath(t, "string", testOpts{String: "hello"}, "string=hello")
+	checkSerializingHappyPath(t, "int", testOpts{Int: -42}, "int=-42")
+	checkSerializingHappyPath(t, "int8", testOpts{Int8: -8}, "int8=-8")
+	checkSerializingHappyPath(t, "int16", testOpts{Int16: -16}, "int16=-16")
+	checkSerializingHappyPath(t, "int32", testOpts{Int32: -32}, "int32=-32")
+	checkSerializingHappyPath(t, "int64", testOpts{Int64: -64}, "int64=-64")
+	checkSerializingHappyPath(t, "uint", testOpts{Uint: 42}, "uint=42")
+	checkSerializingHappyPath(t, "uint8", testOpts{Uint8: 8}, "uint8=8")
+	checkSerializingHappyPath(t, "uint16", testOpts{Uint16: 16}, "uint16=16")
+	checkSerializingHappyPath(t, "uint32", testOpts{Uint32: 32}, "uint32=32")
+	checkSerializingHappyPath(t, "uint64", testOpts{Uint64: 64}, "uint64=64")
+	checkSerializingHappyPath(t, "float32", testOpts{Float32: -1.5}, "float32=-1.5")
+	checkSerializingHappyPath(t, "float64", testOpts{Float64: -2.5}, "float64=-2.5")
+
+	// pointers
+	checkSerializingHappyPath(t, "pointer_struct",
+		testOpts{PointerStruct: &testInnerOpts{Name: "bar", Age: 7}},
+		"pointer_struct.age=7&pointer_struct.name=bar")
+	checkSerializingHappyPath(t, "pointer_bool", testOpts{PointerBool: new(true)}, "pointer_bool=true")
+	checkSerializingHappyPath(t, "pointer_time", testOpts{PointerTime: new(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC))}, "pointer_time=2000-01-01T00%3A00%3A00Z")
+	checkSerializingHappyPath(t, "pointer_string", testOpts{PointerString: new("world")}, "pointer_string=world")
+	checkSerializingHappyPath(t, "pointer_int", testOpts{PointerInt: new(7)}, "pointer_int=7")
+	checkSerializingHappyPath(t, "pointer_int8", testOpts{PointerInt8: new(int8(8))}, "pointer_int8=8")
+	checkSerializingHappyPath(t, "pointer_int16", testOpts{PointerInt16: new(int16(16))}, "pointer_int16=16")
+	checkSerializingHappyPath(t, "pointer_int32", testOpts{PointerInt32: new(int32(32))}, "pointer_int32=32")
+	checkSerializingHappyPath(t, "pointer_int64", testOpts{PointerInt64: new(int64(64))}, "pointer_int64=64")
+	checkSerializingHappyPath(t, "pointer_uint", testOpts{PointerUint: new(uint(7))}, "pointer_uint=7")
+	checkSerializingHappyPath(t, "pointer_uint8", testOpts{PointerUint8: new(uint8(8))}, "pointer_uint8=8")
+	checkSerializingHappyPath(t, "pointer_uint16", testOpts{PointerUint16: new(uint16(16))}, "pointer_uint16=16")
+	checkSerializingHappyPath(t, "pointer_uint32", testOpts{PointerUint32: new(uint32(32))}, "pointer_uint32=32")
+	checkSerializingHappyPath(t, "pointer_uint64", testOpts{PointerUint64: new(uint64(64))}, "pointer_uint64=64")
+	checkSerializingHappyPath(t, "pointer_float32", testOpts{PointerFloat32: new(float32(3.14))}, "pointer_float32=3.14")
+	checkSerializingHappyPath(t, "pointer_float64", testOpts{PointerFloat64: new(2.718)}, "pointer_float64=2.718")
+
+	// slices
+	checkSerializingHappyPath(t, "bool_slice", testOpts{BoolSlice: []bool{true, false, true}}, "bool_slice=true&bool_slice=false&bool_slice=true")
+	checkSerializingHappyPath(t, "time_slice",
+		testOpts{TimeSlice: []time.Time{
+			time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC),
+			time.Date(2001, 1, 1, 0, 0, 0, 0, time.UTC),
+		}},
+		"time_slice=2000-01-01T00%3A00%3A00Z&time_slice=2001-01-01T00%3A00%3A00Z")
+	checkSerializingHappyPath(t, "string_slice", testOpts{StringSlice: []string{"a", "b", "c"}}, "string_slice=a&string_slice=b&string_slice=c")
+	checkSerializingHappyPath(t, "int_slice", testOpts{IntSlice: []int{1, 2, 3}}, "int_slice=1&int_slice=2&int_slice=3")
+	checkSerializingHappyPath(t, "int8_slice", testOpts{Int8Slice: []int8{1, 2, 3}}, "int8_slice=1&int8_slice=2&int8_slice=3")
+	checkSerializingHappyPath(t, "int16_slice", testOpts{Int16Slice: []int16{1, 2, 3}}, "int16_slice=1&int16_slice=2&int16_slice=3")
+	checkSerializingHappyPath(t, "int32_slice", testOpts{Int32Slice: []int32{1, 2, 3}}, "int32_slice=1&int32_slice=2&int32_slice=3")
+	checkSerializingHappyPath(t, "int64_slice", testOpts{Int64Slice: []int64{1, 2, 3}}, "int64_slice=1&int64_slice=2&int64_slice=3")
+	checkSerializingHappyPath(t, "uint_slice", testOpts{UintSlice: []uint{1, 2, 3}}, "uint_slice=1&uint_slice=2&uint_slice=3")
+	checkSerializingHappyPath(t, "uint8_slice", testOpts{Uint8Slice: []uint8{1, 2, 3}}, "uint8_slice=1&uint8_slice=2&uint8_slice=3")
+	checkSerializingHappyPath(t, "uint16_slice", testOpts{Uint16Slice: []uint16{1, 2, 3}}, "uint16_slice=1&uint16_slice=2&uint16_slice=3")
+	checkSerializingHappyPath(t, "uint32_slice", testOpts{Uint32Slice: []uint32{1, 2, 3}}, "uint32_slice=1&uint32_slice=2&uint32_slice=3")
+	checkSerializingHappyPath(t, "uint64_slice", testOpts{Uint64Slice: []uint64{1, 2, 3}}, "uint64_slice=1&uint64_slice=2&uint64_slice=3")
+	checkSerializingHappyPath(t, "float32_slice", testOpts{Float32Slice: []float32{1.5, 2.5}}, "float32_slice=1.5&float32_slice=2.5")
+	checkSerializingHappyPath(t, "float64_slice", testOpts{Float64Slice: []float64{1.5, 2.5}}, "float64_slice=1.5&float64_slice=2.5")
+
+	// slice comma-separated
+	type testSliceCommaSeparatedOpts struct {
+		StringSlice []string `q:"string_slice" format:"comma-separated"`
+	}
+	checkSerializingHappyPath(t, "string_slice comma-separated", testSliceCommaSeparatedOpts{StringSlice: []string{"a", "b", "c"}}, "string_slice=a%2Cb%2Cc")
+
+	// options
+	checkSerializingHappyPath(t, "option_bool", testOpts{OptionBool: Some(true)}, "option_bool=true")
+	checkSerializingHappyPath(t, "option_time",
+		testOpts{OptionTime: Some(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC))},
+		"option_time=2000-01-01T00%3A00%3A00Z")
+	checkSerializingHappyPath(t, "option_string", testOpts{OptionString: Some("hello")}, "option_string=hello")
+	checkSerializingHappyPath(t, "option_int", testOpts{OptionInt: Some(42)}, "option_int=42")
+	checkSerializingHappyPath(t, "option_int8", testOpts{OptionInt8: Some(int8(8))}, "option_int8=8")
+	checkSerializingHappyPath(t, "option_int16", testOpts{OptionInt16: Some(int16(16))}, "option_int16=16")
+	checkSerializingHappyPath(t, "option_int32", testOpts{OptionInt32: Some(int32(32))}, "option_int32=32")
+	checkSerializingHappyPath(t, "option_int64", testOpts{OptionInt64: Some(int64(64))}, "option_int64=64")
+	checkSerializingHappyPath(t, "option_uint", testOpts{OptionUint: Some(uint(42))}, "option_uint=42")
+	checkSerializingHappyPath(t, "option_uint8", testOpts{OptionUint8: Some(uint8(8))}, "option_uint8=8")
+	checkSerializingHappyPath(t, "option_uint16", testOpts{OptionUint16: Some(uint16(16))}, "option_uint16=16")
+	checkSerializingHappyPath(t, "option_uint32", testOpts{OptionUint32: Some(uint32(32))}, "option_uint32=32")
+	checkSerializingHappyPath(t, "option_uint64", testOpts{OptionUint64: Some(uint64(64))}, "option_uint64=64")
+	checkSerializingHappyPath(t, "option_float32", testOpts{OptionFloat32: Some(float32(1.5))}, "option_float32=1.5")
+	checkSerializingHappyPath(t, "option_float64", testOpts{OptionFloat64: Some(2.5)}, "option_float64=2.5")
+
+	// multiple fields at once (url.Values.Encode sorts alphabetically)
+	checkSerializingHappyPath(t, "multiple fields",
+		testOpts{Bool: true, String: "hi", Int: 5, OptionString: Some("world")},
+		"bool=true&int=5&option_string=world&string=hi")
+}
+
+func TestBuildQueryStringErrors(t *testing.T) {
+	// non-struct input
+	_, err := opts.BuildQueryString(42)
+	th.AssertErr(t, "options type is not a struct", err)
+
+	// required field with zero value
+	type requiredOpts struct {
+		Name string `q:"name" required:"true"`
+	}
+	_, err = opts.BuildQueryString(requiredOpts{})
+	th.AssertErr(t, "required query parameter [Name] not set", err)
+}

--- a/opts/serialize_test.go
+++ b/opts/serialize_test.go
@@ -34,8 +34,13 @@ func TestBuildQueryStringHappyPaths(t *testing.T) {
 	// empty struct (all zero values omitted)
 	checkSerializingHappyPath(t, "empty", testOpts{}, "")
 
+	// embedded string
+	checkSerializingHappyPath(t, "embedded_string", testOpts{EmbeddedOpts: EmbeddedOpts{EmbeddedString: "hello"}}, "embedded_string=hello")
+
 	// map
 	checkSerializingHappyPath(t, "string_map", testOpts{StringMap: map[string]string{"k1": "v1", "k2": "v2"}}, "string_map=k1%3Av1&string_map=k2%3Av2")
+	checkSerializingHappyPath(t, "int_string_map", testOpts{IntStringMap: map[int]string{1: "foo", 2: "bar"}}, "int_string_map=1%3Afoo&int_string_map=2%3Abar")
+	checkSerializingHappyPath(t, "string_int_map", testOpts{StringIntMap: map[string]int{"foo": 1, "bar": 2}}, "string_int_map=bar%3A2&string_int_map=foo%3A1")
 
 	// time
 	checkSerializingHappyPath(t, "time",
@@ -175,8 +180,16 @@ func TestBuildQueryStringErrors(t *testing.T) {
 	type testNonOpts struct {
 		String string `yaml:"string"`
 	}
-	checkParsingPanic(t, `expected "String" to have a "q:"-tag`, func() {
+	checkSerializingPanic(t, `expected "String" to have a "q:"-tag`, func() {
 		opts.BuildQueryString(testNonOpts{}) //nolint:errcheck // won't get to this part
+	})
+
+	// embedded struct with q-tag (panics)
+	type testEmbeddedQTagOpts struct {
+		EmbeddedOpts `q:"embedded"`
+	}
+	checkSerializingPanic(t, `expected embedded struct "EmbeddedOpts" to have no "q:"-tag`, func() {
+		opts.BuildQueryString(testEmbeddedQTagOpts{}) //nolint:errcheck // won't get to this part
 	})
 
 	// unknown struct parameter (panics)
@@ -186,7 +199,7 @@ func TestBuildQueryStringErrors(t *testing.T) {
 	type testNested2 struct {
 		Nested testNested `q:"nested"`
 	}
-	checkParsingPanic(t, "for structs only time.Time and implementers of isZeroer are supported", func() {
+	checkSerializingPanic(t, "for structs only time.Time and implementers of isZeroer are supported", func() {
 		opts.BuildQueryString(testNested2{}) //nolint:errcheck // won't get to this part
 	})
 
@@ -194,7 +207,7 @@ func TestBuildQueryStringErrors(t *testing.T) {
 	type testBadTimeFormatOpts struct {
 		Time time.Time `q:"time,format:foo"`
 	}
-	checkSerializingPanic(t, "unknown time format foo", func() {
+	checkSerializingPanic(t, `unsupported time format "foo"; accepted: DateOnly, DateTime, RFC3339, RFC3339Nano, Unix`, func() {
 		opts.BuildQueryString(testBadTimeFormatOpts{Time: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)}) //nolint:errcheck // won't get to this part
 	})
 

--- a/opts/util.go
+++ b/opts/util.go
@@ -12,18 +12,16 @@ import (
 )
 
 var (
-	// timeFormats lists all allowed formats, except "Unix" which is handled separately.
-	timeFormats = map[string]string{
+	// TimeFormats lists all allowed formats supported by the time package, except "Unix" (see below).
+	TimeFormats = map[string]string{
 		"RFC3339Nano": time.RFC3339Nano,
 		"RFC3339":     time.RFC3339,
 		"DateTime":    time.DateTime,
 		"DateOnly":    time.DateOnly,
 	}
-	supportedHumanReadableFormats = strings.Join(slices.Sorted(maps.Keys(timeFormats)), ", ")
-)
-
-const (
-	unixFormat = "Unix"
+	// UnixFormat is an identifier for the time to be interpreted as unix-seconds since epoch.
+	UnixFormat                    = "Unix"
+	supportedHumanReadableFormats = strings.Join(slices.Sorted(maps.Keys(TimeFormats)), ", ") + ", " + UnixFormat
 )
 
 // parseQTag parses a q struct tag value into its key name, optional format, and required flag.

--- a/opts/util.go
+++ b/opts/util.go
@@ -59,7 +59,10 @@ func parseQTag(tag string) (key string, format Option[string], required bool) {
 // typeNeedsTimeFormat reports whether t contains time.Time at any level
 // of indirection (pointer, slice element, map value, or Option inner type).
 func typeNeedsTimeFormat(t reflect.Type) bool {
-	if slices.Contains([]reflect.Kind{reflect.Pointer, reflect.Slice, reflect.Array, reflect.Map}, t.Kind()) {
+	if t.Kind() == reflect.Map {
+		return typeNeedsTimeFormat(t.Key()) || typeNeedsTimeFormat(t.Elem())
+	}
+	if slices.Contains([]reflect.Kind{reflect.Pointer, reflect.Slice, reflect.Array}, t.Kind()) {
 		return typeNeedsTimeFormat(t.Elem())
 	}
 	if t == reflect.TypeFor[time.Time]() {

--- a/opts/util.go
+++ b/opts/util.go
@@ -4,24 +4,27 @@
 package opts
 
 import (
+	"fmt"
 	"maps"
 	"reflect"
 	"slices"
 	"strings"
 	"time"
+
+	. "go.xyrillian.de/gg/option"
 )
 
 var (
-	// TimeFormats lists all allowed formats supported by the time package, except "Unix" (see below).
-	TimeFormats = map[string]string{
+	// timeFormats lists all allowed formats supported by the time package, except "Unix" (see below).
+	nonUnixTimeFormats = map[string]string{
 		"RFC3339Nano": time.RFC3339Nano,
 		"RFC3339":     time.RFC3339,
 		"DateTime":    time.DateTime,
 		"DateOnly":    time.DateOnly,
 	}
-	// UnixFormat is an identifier for the time to be interpreted as unix-seconds since epoch.
-	UnixFormat                    = "Unix"
-	supportedHumanReadableFormats = strings.Join(slices.Sorted(maps.Keys(TimeFormats)), ", ") + ", " + UnixFormat
+	// unixFormat is an identifier for the time to be interpreted as unix-seconds since epoch.
+	unixTimeFormat                = "Unix"
+	supportedHumanReadableFormats = strings.Join(slices.Sorted(slices.Values(append(slices.Collect(maps.Keys(nonUnixTimeFormats)), unixTimeFormat))), ", ")
 )
 
 // parseQTag parses a q struct tag value into its key name, optional format, and required flag.
@@ -32,62 +35,52 @@ var (
 //	`q:"updated_at,format:Unix"`          → key="updated_at", format="Unix", required=false
 //	`q:"updated_at,required"`             → key="updated_at", format="", required=true
 //	`q:"updated_at,format:Unix,required"` → key="updated_at", format="Unix", required=true
-func parseQTag(tag string) (key, format string, required bool) {
+func parseQTag(tag string) (key string, format Option[string], required bool) {
 	parts := strings.SplitN(tag, ",", 2)
 	key = parts[0]
 	if len(parts) > 1 {
 		for opt := range strings.SplitSeq(parts[1], ",") {
 			if after, found := strings.CutPrefix(opt, "format:"); found {
-				format = after
+				// all known formats are currently for time
+				if _, ok := nonUnixTimeFormats[after]; after != unixTimeFormat && !ok {
+					panic(fmt.Sprintf("unsupported time format %q; accepted: %s", after, supportedHumanReadableFormats))
+				}
+				format = Some(after)
 			} else if opt == "required" {
 				required = true
+			} else {
+				panic("unrecognized option on tag " + tag)
 			}
 		}
 	}
 	return key, format, required
 }
 
-// isZero checks if a value is the zero value for its type. For scalar values,
-// it uses reflect. Only certain structs are allowed: Ones that implement the
-// isZeroer interface and time.Time. For arrays it checks each element. For
-// pointer, funcs, maps and slices reflect.IsNil can be used.
-func isZero(v reflect.Value) bool {
-	// Check for types implementing IsZero() bool (e.g. Option[T], time.Time).
-	// Guard against nil pointers whose element type has pointer-receiver IsZero.
-	type isZeroer interface{ IsZero() bool }
-	if v.Kind() == reflect.Ptr { //nolint:govet // won't inline this...
-		if v.IsNil() {
-			return true
-		}
-		// Dereference the pointer and check the element.
-		return isZero(v.Elem())
+// typeNeedsTimeFormat reports whether t contains time.Time at any level
+// of indirection (pointer, slice element, map value, or Option inner type).
+func typeNeedsTimeFormat(t reflect.Type) bool {
+	if slices.Contains([]reflect.Kind{reflect.Pointer, reflect.Slice, reflect.Array, reflect.Map}, t.Kind()) {
+		return typeNeedsTimeFormat(t.Elem())
 	}
-	if v.CanInterface() {
-		if z, ok := v.Interface().(isZeroer); ok {
-			return z.IsZero()
-		}
+	if t == reflect.TypeFor[time.Time]() {
+		return true
 	}
-
-	switch v.Kind() {
-	case reflect.Func, reflect.Map, reflect.Slice:
-		return v.IsNil()
-	case reflect.Array:
-		z := true
-		for i := range v.Len() {
-			z = z && isZero(v.Index(i))
+	// Option[T]: detected by IsSome method, inner type via UnmarshalYAML contract
+	if _, isOption := t.MethodByName("IsSome"); isOption {
+		var innerType reflect.Type
+		probe := func(dest any) error {
+			// dest is **T → Elem() is *T → Elem() is T
+			innerType = reflect.TypeOf(dest).Elem().Elem()
+			return nil
 		}
-		return z
-	case reflect.Struct:
-		if v.Type() != reflect.TypeFor[time.Time]() {
-			panic("for structs only time.Time and implementers of isZeroer are supported")
+		type yamlUnmarshaler interface {
+			UnmarshalYAML(func(any) error) error
 		}
-		z := true
-		for _, structField := range v.Fields() {
-			z = z && isZero(structField)
+		err := reflect.New(t).Interface().(yamlUnmarshaler).UnmarshalYAML(probe)
+		if err != nil {
+			panic(fmt.Sprintf("failed to probe inner type of Option: %v", err))
 		}
-		return z
-	default:
-		z := reflect.Zero(v.Type())
-		return v.Interface() == z.Interface()
+		return typeNeedsTimeFormat(innerType)
 	}
+	return false
 }

--- a/opts/util.go
+++ b/opts/util.go
@@ -37,10 +37,9 @@ var (
 //	`q:"updated_at,format:Unix,required"` → key="updated_at", format=Some("Unix"), value=None, required=true
 //	`q:"with,value:details"`              → key="with", format=None, value=Some("details"), required=false
 func parseQTag(tag string) (key string, format, value Option[string], required bool) {
-	parts := strings.SplitN(tag, ",", 2)
-	key = parts[0]
-	if len(parts) > 1 {
-		for opt := range strings.SplitSeq(parts[1], ",") {
+	key, options, hasOptions := strings.Cut(tag, ",")
+	if hasOptions {
+		for opt := range strings.SplitSeq(options, ",") {
 			if after, found := strings.CutPrefix(opt, "format:"); found {
 				// all known formats are currently for time
 				if _, ok := nonUnixTimeFormats[after]; after != unixTimeFormat && !ok {

--- a/opts/util.go
+++ b/opts/util.go
@@ -27,15 +27,16 @@ var (
 	supportedHumanReadableFormats = strings.Join(slices.Sorted(slices.Values(append(slices.Collect(maps.Keys(nonUnixTimeFormats)), unixTimeFormat))), ", ")
 )
 
-// parseQTag parses a q struct tag value into its key name, optional format, and required flag.
-// The tag format is "key_name" or "key_name,format:FormatName,required".
+// parseQTag parses a q struct tag value into its key name, optional format, optional value discriminant, and required flag.
+// The tag format is "key_name" or "key_name,format:FormatName,required,value:ValueName".
 // Examples:
 //
-//	`q:"updated_at"`                      → key="updated_at", format="", required=false
-//	`q:"updated_at,format:Unix"`          → key="updated_at", format="Unix", required=false
-//	`q:"updated_at,required"`             → key="updated_at", format="", required=true
-//	`q:"updated_at,format:Unix,required"` → key="updated_at", format="Unix", required=true
-func parseQTag(tag string) (key string, format Option[string], required bool) {
+//	`q:"updated_at"`                      → key="updated_at", format=None, value=None, required=false
+//	`q:"updated_at,format:Unix"`          → key="updated_at", format=Some("Unix"), value=None, required=false
+//	`q:"updated_at,required"`             → key="updated_at", format=None, value=None, required=true
+//	`q:"updated_at,format:Unix,required"` → key="updated_at", format=Some("Unix"), value=None, required=true
+//	`q:"with,value:details"`              → key="with", format=None, value=Some("details"), required=false
+func parseQTag(tag string) (key string, format, value Option[string], required bool) {
 	parts := strings.SplitN(tag, ",", 2)
 	key = parts[0]
 	if len(parts) > 1 {
@@ -46,6 +47,8 @@ func parseQTag(tag string) (key string, format Option[string], required bool) {
 					panic(fmt.Sprintf("unsupported time format %q; accepted: %s", after, supportedHumanReadableFormats))
 				}
 				format = Some(after)
+			} else if after, found := strings.CutPrefix(opt, "value:"); found {
+				value = Some(after)
 			} else if opt == "required" {
 				required = true
 			} else {
@@ -53,7 +56,7 @@ func parseQTag(tag string) (key string, format Option[string], required bool) {
 			}
 		}
 	}
-	return key, format, required
+	return key, format, value, required
 }
 
 // typeNeedsTimeFormat reports whether t contains time.Time at any level

--- a/opts/util.go
+++ b/opts/util.go
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package opts
+
+import (
+	"maps"
+	"reflect"
+	"slices"
+	"strings"
+	"time"
+)
+
+var (
+	// timeFormats lists all allowed formats, except "Unix" which is handled separately.
+	timeFormats = map[string]string{
+		"RFC3339Nano": time.RFC3339Nano,
+		"RFC3339":     time.RFC3339,
+		"DateTime":    time.DateTime,
+		"DateOnly":    time.DateOnly,
+	}
+	supportedHumanReadableFormats = strings.Join(slices.Sorted(maps.Keys(timeFormats)), ", ")
+)
+
+const (
+	unixFormat           = "Unix"
+	commaSeparatedFormat = "comma-separated"
+)
+
+// isZero checks if a value is the zero value for its type. For scalar values,
+// it uses reflect. For structs it checks each field, except structs that
+// implement the isZeroer interface. For arrays it checks each element. For
+// pointer, funcs, maps and slices reflect.IsNil can be used.
+func isZero(v reflect.Value) bool {
+	// Check for types implementing IsZero() bool (e.g. Option[T], time.Time).
+	// Guard against nil pointers whose element type has pointer-receiver IsZero.
+	type isZeroer interface{ IsZero() bool }
+	if v.Kind() == reflect.Ptr { //nolint:govet // won't inline this...
+		if v.IsNil() {
+			return true
+		}
+		// Dereference the pointer and check the element.
+		return isZero(v.Elem())
+	}
+	if v.CanInterface() {
+		if z, ok := v.Interface().(isZeroer); ok {
+			return z.IsZero()
+		}
+	}
+
+	switch v.Kind() {
+	case reflect.Func, reflect.Map, reflect.Slice:
+		return v.IsNil()
+	case reflect.Array:
+		z := true
+		for i := range v.Len() {
+			z = z && isZero(v.Index(i))
+		}
+		return z
+	case reflect.Struct:
+		z := true
+		for _, structField := range v.Fields() {
+			z = z && isZero(structField)
+		}
+		return z
+	default:
+		z := reflect.Zero(v.Type())
+		return v.Interface() == z.Interface()
+	}
+}

--- a/opts/util.go
+++ b/opts/util.go
@@ -23,13 +23,35 @@ var (
 )
 
 const (
-	unixFormat           = "Unix"
-	commaSeparatedFormat = "comma-separated"
+	unixFormat = "Unix"
 )
 
+// parseQTag parses a q struct tag value into its key name, optional format, and required flag.
+// The tag format is "key_name" or "key_name,format:FormatName,required".
+// Examples:
+//
+//	`q:"updated_at"`                      → key="updated_at", format="", required=false
+//	`q:"updated_at,format:Unix"`          → key="updated_at", format="Unix", required=false
+//	`q:"updated_at,required"`             → key="updated_at", format="", required=true
+//	`q:"updated_at,format:Unix,required"` → key="updated_at", format="Unix", required=true
+func parseQTag(tag string) (key, format string, required bool) {
+	parts := strings.SplitN(tag, ",", 2)
+	key = parts[0]
+	if len(parts) > 1 {
+		for opt := range strings.SplitSeq(parts[1], ",") {
+			if after, found := strings.CutPrefix(opt, "format:"); found {
+				format = after
+			} else if opt == "required" {
+				required = true
+			}
+		}
+	}
+	return key, format, required
+}
+
 // isZero checks if a value is the zero value for its type. For scalar values,
-// it uses reflect. For structs it checks each field, except structs that
-// implement the isZeroer interface. For arrays it checks each element. For
+// it uses reflect. Only certain structs are allowed: Ones that implement the
+// isZeroer interface and time.Time. For arrays it checks each element. For
 // pointer, funcs, maps and slices reflect.IsNil can be used.
 func isZero(v reflect.Value) bool {
 	// Check for types implementing IsZero() bool (e.g. Option[T], time.Time).
@@ -58,6 +80,9 @@ func isZero(v reflect.Value) bool {
 		}
 		return z
 	case reflect.Struct:
+		if v.Type() != reflect.TypeFor[time.Time]() {
+			panic("for structs only time.Time and implementers of isZeroer are supported")
+		}
 		z := true
 		for _, structField := range v.Fields() {
 			z = z && isZero(structField)


### PR DESCRIPTION
This PR adds `BuildQueryString`, originally from https://github.com/sapcc/gophercloud/blob/master/params.go.
Background is that we needed to build the opposite function `ParseQueryString` in go-api-declarations, so that we can reference it from `Opts` structs which we want to re-use in api-declarations. Because these 2 functions can share some code (`isZero` function), I moved this together here and enhanced `BuildQueryString` a bit.

The test cases are quite elaborate in places, e.g. they test `int, int8, int16` and so forth always separately. 

I am not very satisfied with the code structure, working with reflections always results in ugly code for me. If you have ideas how to structure this better, feel free to add commits as well. 