### PR TITLE
opts: unify struct type analysis between {Parse,Build}QueryString()

### DIFF
--- a/opts/analyze.go
+++ b/opts/analyze.go
@@ -4,9 +4,11 @@
 package opts
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"sync"
+	"time"
 
 	. "go.xyrillian.de/gg/option"
 )
@@ -98,7 +100,7 @@ func buildStructInfo(t reflect.Type) structInfo {
 				si.FlagSets[key] = flagSetInfo{Indexes: make(map[string][]int)}
 			}
 			if _, exists := si.FlagSets[key].Indexes[value]; exists {
-				panicf(`value %q for key %q is declared on multiple fields`, key, value)
+				panicf(`value %q for key %q is declared on multiple fields`, value, key)
 			}
 			si.FlagSets[key].Indexes[value] = field.Index
 			continue
@@ -110,6 +112,10 @@ func buildStructInfo(t reflect.Type) structInfo {
 		}
 		if _, exists := si.Options[key]; exists {
 			panicf(`key %q is declared on multiple fields`, key)
+		}
+		err := checkFieldTypeAllowed(field.Type)
+		if err != nil {
+			panic(err.Error())
 		}
 		si.Options[key] = optionInfo{
 			Index:      field.Index,
@@ -125,4 +131,46 @@ func buildStructInfo(t reflect.Type) structInfo {
 	}
 
 	return si
+}
+
+var (
+	timeType      = reflect.TypeFor[time.Time]()
+	anyOptionType = reflect.TypeFor[interface{ IsSome() bool }]()
+)
+
+// checkFieldTypeAllowed validates if the given type is allowed as a field within an option struct.
+func checkFieldTypeAllowed(t reflect.Type) error {
+	// a single level of pointer indirection is allowed
+	if t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+
+	switch {
+	case isScalarFieldType(t):
+		return nil
+	case t.Kind() == reflect.Struct:
+		if t == timeType || t.Implements(anyOptionType) {
+			return nil
+		}
+		return errors.New("structs other than time.Time and option.Option[T] are not supported")
+	case t.Kind() == reflect.Slice:
+		elementType := t.Elem()
+		if elementType == reflect.TypeFor[time.Time]() || isScalarFieldType(elementType) {
+			return nil
+		}
+		zero := reflect.New(elementType).Elem().Interface()
+		return fmt.Errorf("slices of type %T are not supported", zero)
+	case t.Kind() == reflect.Map:
+		if !isScalarFieldType(t.Key()) {
+			zero := reflect.New(t.Key()).Elem().Interface()
+			return fmt.Errorf("map keys of type %T are not supported", zero)
+		}
+		if !isScalarFieldType(t.Elem()) {
+			zero := reflect.New(t.Elem()).Elem().Interface()
+			return fmt.Errorf("map values of type %T are not supported", zero)
+		}
+		return nil
+	default:
+		return fmt.Errorf("fields of kind %s are not supported", t.Kind())
+	}
 }

--- a/opts/analyze.go
+++ b/opts/analyze.go
@@ -66,10 +66,6 @@ func buildStructInfo(t reflect.Type) structInfo {
 		panic("options type is not a struct")
 	}
 	for _, field := range reflect.VisibleFields(t) {
-		if !field.IsExported() {
-			panicf(`field %q is unexported and therefore cannot be set`, field.Name)
-		}
-
 		// ignore embedded fields themselves and only consider the fields within embedded structs
 		qTag := field.Tag.Get("q")
 		if field.Anonymous {
@@ -77,6 +73,12 @@ func buildStructInfo(t reflect.Type) structInfo {
 				panicf(`expected embedded struct %q to have no "q:"-tag`, field.Name)
 			}
 			continue
+		}
+
+		// this check must come after ignoring embedded fields, because unexported
+		// anonymous fields are fine and can indeed be traversed into
+		if !field.IsExported() {
+			panicf(`field %q is unexported and therefore cannot be set`, field.Name)
 		}
 
 		// parse "q:"-tag

--- a/opts/analyze.go
+++ b/opts/analyze.go
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package opts
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+
+	. "go.xyrillian.de/gg/option"
+)
+
+// structInfo holds information about a struct type that can be used with ParseQueryString() or BuildQueryString().
+type structInfo struct {
+	Options  map[string]optionInfo
+	FlagSets map[string]flagSetInfo
+}
+
+// optionInfo holds information about an option field that can appear in a query string.
+// It appears in type [structInfo].
+type optionInfo struct {
+	Index      []int          // argument for reflect.Value.FieldByIndex()
+	TimeFormat Option[string] // only for time.Time-valued fields or pointers/options thereof
+	Required   bool
+}
+
+// flagSetInfo holds information about a key that can appear in a query string, and which is backed by several boolean flags.
+// It appears in type [structInfo].
+type flagSetInfo struct {
+	Indexes map[string][]int // key = option value (e.g. "detail" in "?with=detail"), value = argument for reflect.Value.FieldByIndex()
+}
+
+var (
+	structInfoCache      = make(map[reflect.Type]structInfo)
+	structInfoCacheMutex sync.Mutex
+)
+
+func getStructInfo(t reflect.Type) structInfo {
+	// not using an RWMutex here to simplify the implementation
+	// (this critical section is extremely fast most of the time,
+	// so the mutex is not likely to be contended)
+	structInfoCacheMutex.Lock()
+	defer structInfoCacheMutex.Unlock()
+	si, exists := structInfoCache[t]
+	if !exists {
+		si = buildStructInfo(t)
+		structInfoCache[t] = si
+	}
+	return si
+}
+
+func panicf(msg string, args ...any) {
+	panic(fmt.Sprintf(msg, args...))
+}
+
+func buildStructInfo(t reflect.Type) structInfo {
+	si := structInfo{
+		Options:  make(map[string]optionInfo),
+		FlagSets: make(map[string]flagSetInfo),
+	}
+
+	if t.Kind() != reflect.Struct {
+		panic("options type is not a struct")
+	}
+	for _, field := range reflect.VisibleFields(t) {
+		if !field.IsExported() {
+			panicf(`field %q is unexported and therefore cannot be set`, field.Name)
+		}
+
+		// ignore embedded fields themselves and only consider the fields within embedded structs
+		qTag := field.Tag.Get("q")
+		if field.Anonymous {
+			if qTag != "" {
+				panicf(`expected embedded struct %q to have no "q:"-tag`, field.Name)
+			}
+			continue
+		}
+
+		// parse "q:"-tag
+		if qTag == "" {
+			panicf(`expected %q to have a "q:"-tag`, field.Name)
+		}
+		key, maybeTimeFormat, maybeValue, required := parseQTag(qTag)
+
+		// case 1: field is a flag set
+		if value, ok := maybeValue.Unpack(); ok {
+			if field.Type.Kind() != reflect.Bool {
+				panicf(`field %q has "value:" option but is not a bool`, field.Name)
+			}
+			if required {
+				panicf(`field %q cannot have both "value:" and "required" options`, field.Name)
+			}
+			if maybeTimeFormat.IsSome() {
+				panicf(`field %q cannot have both "value:" and "format:" options`, field.Name)
+			}
+			if _, exists := si.FlagSets[key]; !exists {
+				si.FlagSets[key] = flagSetInfo{Indexes: make(map[string][]int)}
+			}
+			if _, exists := si.FlagSets[key].Indexes[value]; exists {
+				panicf(`value %q for key %q is declared on multiple fields`, key, value)
+			}
+			si.FlagSets[key].Indexes[value] = field.Index
+			continue
+		}
+
+		// case 2: field is an option
+		if typeNeedsTimeFormat(field.Type) && maybeTimeFormat.IsNone() {
+			panicf(`time format is missing for field %q`, field.Name)
+		}
+		if _, exists := si.Options[key]; exists {
+			panicf(`key %q is declared on multiple fields`, key)
+		}
+		si.Options[key] = optionInfo{
+			Index:      field.Index,
+			TimeFormat: maybeTimeFormat,
+			Required:   required,
+		}
+	}
+
+	for key := range si.FlagSets {
+		if _, exists := si.Options[key]; exists {
+			panic(fmt.Sprintf(`key %q cannot be declared as both a regular field and a value-discriminant field`, key))
+		}
+	}
+
+	return si
+}

--- a/opts/analyze.go
+++ b/opts/analyze.go
@@ -149,8 +149,20 @@ func checkFieldTypeAllowed(t reflect.Type) error {
 	case isScalarFieldType(t):
 		return nil
 	case t.Kind() == reflect.Struct:
-		if t == timeType || t.Implements(anyOptionType) {
+		if t == timeType {
 			return nil
+		}
+		if t.Implements(anyOptionType) {
+			// Option.UnwrapOr() returns T, so that's an easy way to get to the contained type
+			if m, ok := t.MethodByName("UnwrapOr"); ok {
+				payloadType := m.Type.Out(0)
+				if isScalarFieldType(payloadType) || payloadType == timeType {
+					return nil
+				} else {
+					zero := reflect.New(payloadType).Elem().Interface()
+					return fmt.Errorf("option.Option[T] with structured payload T = %T is not supported", zero)
+				}
+			}
 		}
 		return errors.New("structs other than time.Time and option.Option[T] are not supported")
 	case t.Kind() == reflect.Slice:

--- a/opts/analyze_test.go
+++ b/opts/analyze_test.go
@@ -130,6 +130,10 @@ func TestAnalyzePanics(t *testing.T) {
 		Query    string           `q:"query"`
 		Settings []Option[string] `q:"settings"`
 	}](t, `slices of type option.Option[string] are not supported`)
+	expectAnalyzePanic[struct {
+		Query    string                    `q:"query"`
+		Settings Option[map[string]string] `q:"settings"`
+	}](t, `option.Option[T] with structured payload T = map[string]string is not supported`)
 
 	type point struct {
 		X int

--- a/opts/analyze_test.go
+++ b/opts/analyze_test.go
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package opts_test
+
+import (
+	"net/url"
+	"testing"
+	"time"
+
+	. "go.xyrillian.de/gg/option"
+
+	"github.com/sapcc/go-api-declarations/opts"
+)
+
+func expectPanic(t *testing.T, panicMsg string, fn func()) {
+	t.Helper()
+	defer func() {
+		t.Helper()
+		r := recover()
+		if r == nil {
+			t.Errorf("expected panic %q, but function did not panic", panicMsg)
+			return
+		}
+		got, ok := r.(string)
+		if !ok {
+			t.Errorf("expected panic with string %q, but got non-string panic: %v", panicMsg, r)
+			return
+		}
+		if got != panicMsg {
+			t.Errorf("expected panic: %s, but got: %s", panicMsg, got)
+		}
+	}()
+	fn()
+}
+
+func expectAnalyzePanic[T any](t *testing.T, panicMsg string) {
+	// Errors that are raised by buildStructInfo() should be visible both in
+	// BuildQueryString() and ParseQueryString(), because both use buildStructInfo().
+	t.Helper()
+	expectPanic(t, panicMsg, func() {
+		t.Helper()
+		var zero T
+		_, _ = opts.BuildQueryString(zero) //nolint:errcheck // panics before returning
+	})
+	expectPanic(t, panicMsg, func() {
+		t.Helper()
+		_, _ = opts.ParseQueryString[T](url.Values{}) //nolint:errcheck // panics before returning
+	})
+}
+
+func TestAnalyzePanics(t *testing.T) {
+	// non-struct type parameter (panics)
+	expectAnalyzePanic[int](t, "options type is not a struct")
+
+	// unexported field
+	expectAnalyzePanic[struct {
+		data string `q:"data"`
+	}](t, `field "data" is unexported and therefore cannot be set`)
+
+	// missing q-tag
+	expectAnalyzePanic[struct {
+		String string `yaml:"string"`
+	}](t, `expected "String" to have a "q:"-tag`)
+
+	// embedded struct with q-tag
+	expectAnalyzePanic[struct {
+		EmbeddedOpts `q:"embedded"`
+	}](t, `expected embedded struct "EmbeddedOpts" to have no "q:"-tag`)
+
+	// duplicate field declarations
+	expectAnalyzePanic[struct {
+		FooBar    string `q:"foo_bar"`
+		FooAndBar string `q:"foo_bar"`
+	}](t, `key "foo_bar" is declared on multiple fields`)
+
+	// contradictory field declarations
+	expectAnalyzePanic[struct {
+		Scope   string   `q:"scope"`
+		With    []string `q:"with"`
+		WithFoo bool     `q:"with,value:foo"`
+		WithBar bool     `q:"with,value:bar"`
+	}](t, `key "with" cannot be declared as both a regular field and a value-discriminant field`)
+
+	// invalid flagset declarations
+	expectAnalyzePanic[struct {
+		WithFoo bool `q:"with,value:foo"`
+		WithBar int  `q:"with,value:bar"`
+	}](t, `field "WithBar" has "value:" option but is not a bool`)
+	expectAnalyzePanic[struct {
+		WithFoo bool `q:"with,value:foo,required"`
+		WithBar bool `q:"with,value:bar"`
+	}](t, `field "WithFoo" cannot have both "value:" and "required" options`)
+	expectAnalyzePanic[struct {
+		WithFoo bool `q:"with,value:foo,format:Unix"`
+		WithBar bool `q:"with,value:bar"`
+	}](t, `field "WithFoo" cannot have both "value:" and "format:" options`)
+	expectAnalyzePanic[struct {
+		WithFoo      bool `q:"with,value:foo"`
+		WithFooAgain bool `q:"with,value:foo"`
+	}](t, `value "foo" for key "with" is declared on multiple fields`)
+
+	// unknown struct parameter
+	type testNested struct {
+		String string `q:"string"`
+	}
+	expectAnalyzePanic[struct {
+		Nested testNested `q:"nested"`
+	}](t, "structs other than time.Time and option.Option[T] are not supported")
+
+	// unknown time format
+	expectAnalyzePanic[struct {
+		Time time.Time `q:"time,format:foo"`
+	}](t, `unsupported time format "foo"; accepted: DateOnly, DateTime, RFC3339, RFC3339Nano, Unix`)
+	expectAnalyzePanic[struct {
+		Time time.Time `q:"time"`
+	}](t, `time format is missing for field "Time"`)
+
+	// invalid field types
+	expectAnalyzePanic[struct {
+		Query    string          `q:"query"`
+		Callback func(any) error `q:"callback"`
+	}](t, `fields of kind func are not supported`)
+
+	expectAnalyzePanic[struct {
+		Query  string  `q:"query"`
+		Matrix [][]int `q:"matrix"`
+	}](t, `slices of type []int are not supported`)
+	expectAnalyzePanic[struct {
+		Query    string           `q:"query"`
+		Settings []Option[string] `q:"settings"`
+	}](t, `slices of type option.Option[string] are not supported`)
+
+	type point struct {
+		X int
+		Y int
+	}
+	expectAnalyzePanic[struct {
+		Query string           `q:"query"`
+		POIs  map[point]string `q:"poi"`
+	}](t, `map keys of type opts_test.point are not supported`)
+	expectAnalyzePanic[struct {
+		Query string           `q:"query"`
+		POIs  map[string]point `q:"poi"`
+	}](t, `map values of type opts_test.point are not supported`)
+}

--- a/opts/parse.go
+++ b/opts/parse.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/url"
 	"reflect"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -168,8 +167,7 @@ func setField(fv reflect.Value, values []string, timeFormat Option[string]) erro
 	}
 
 	// some common error checks
-	if slices.Contains([]reflect.Kind{reflect.String, reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint,
-		reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Bool, reflect.Float32, reflect.Float64}, fv.Kind()) || fv.Type() == reflect.TypeFor[time.Time]() {
+	if isScalarFieldType(fv.Type()) || fv.Type() == reflect.TypeFor[time.Time]() {
 		if len(values) == 0 {
 			return nil
 		}

--- a/opts/parse.go
+++ b/opts/parse.go
@@ -228,6 +228,7 @@ func setField(fv reflect.Value, values []string, timeFormat Option[string]) erro
 		}
 		fv.Set(m)
 	default:
+		// defense in depth: should have been rejected in checkFieldTypeAllowed()
 		return fmt.Errorf("unsupported field type %s", fv.Type())
 	}
 	return nil
@@ -265,6 +266,7 @@ func parseScalar(s string, t reflect.Type) (reflect.Value, error) {
 		}
 		v.SetBool(b)
 	default:
+		// defense in depth: should not call this function for kinds not handled above
 		return reflect.Value{}, fmt.Errorf("unsupported type %s", t)
 	}
 	return v, nil

--- a/opts/parse.go
+++ b/opts/parse.go
@@ -77,110 +77,52 @@ import (
 //
 // [option.Option]: https://pkg.go.dev/go.xyrillian.de/gg/option#Option
 func ParseQueryString[T any](query url.Values) (T, error) {
+	// NOTE: This function body should be as short as possible to reduce the binary size after monomorphization.
+	//       Any expression that does not depend on type T should be factored out into a reusable function.
 	var opts T
-	optsValue := reflect.ValueOf(&opts).Elem()
-	if optsValue.Kind() != reflect.Struct {
-		panic("expected opts to point to a struct")
-	}
+	err := parseQueryString(query, reflect.ValueOf(&opts).Elem())
+	return opts, err
+}
 
-	// build map of q-tags to field values
-	optsType := optsValue.Type()
-	type optMeta struct {
-		structField       reflect.StructField
-		fieldValue        reflect.Value
-		maybeTimeFormat   Option[string]
-		requiredAndUnseen bool
-	}
-	knownOpts := make(map[string]optMeta, optsType.NumField())
-	valueFields := make(map[string]map[string]reflect.Value) // key → list of value-discriminant bools
-	for _, field := range reflect.VisibleFields(optsType) {
-		fieldValue := optsValue.FieldByIndex(field.Index)
-		qTag := field.Tag.Get("q")
-		if field.Anonymous {
-			// this is for struct embedding to work
-			if qTag != "" {
-				panic(fmt.Sprintf(`expected embedded struct %q to have no "q:"-tag`, field.Name))
-			}
-			continue
-		}
-		if qTag == "" {
-			panic(fmt.Sprintf(`expected %q to have a "q:"-tag`, field.Name))
-		}
-		optKey, maybeTimeFormat, maybeValue, required := parseQTag(qTag)
-		if !fieldValue.CanSet() {
-			panic(fmt.Sprintf(`field %q is unexported and therefore cannot be set`, field.Name))
-		}
-
-		// value-discriminant fields go into a separate structure
-		if value, ok := maybeValue.Unpack(); ok {
-			if fieldValue.Kind() != reflect.Bool {
-				panic(fmt.Sprintf(`field %q has "value:" option but is not a bool`, field.Name))
-			}
-			if maybeTimeFormat.IsSome() {
-				panic(fmt.Sprintf(`field %q cannot have both "value:" and "format:" options`, field.Name))
-			}
-			if _, keyExists := valueFields[optKey]; !keyExists {
-				valueFields[optKey] = make(map[string]reflect.Value)
-			}
-			valueFields[optKey][value] = fieldValue
-			continue
-		}
-
-		// check if format is set when required
-		if typeNeedsTimeFormat(fieldValue.Type()) && maybeTimeFormat.IsNone() {
-			panic(fmt.Sprintf(`time format is missing for field %q`, field.Name))
-		}
-
-		knownOpts[optKey] = optMeta{
-			structField:       field,
-			fieldValue:        fieldValue,
-			maybeTimeFormat:   maybeTimeFormat,
-			requiredAndUnseen: required,
-		}
-	}
-
-	// keys may not be used for both regular fields and value-discriminant fields
-	for optKey := range valueFields {
-		if _, exists := knownOpts[optKey]; exists {
-			panic(fmt.Sprintf(`key %q cannot be declared as both a regular field and a value-discriminant field`, optKey))
-		}
-	}
+func parseQueryString(query url.Values, optsValue reflect.Value) error {
+	si := getStructInfo(optsValue.Type())
 
 	// iterate the query
-	for optKey, rawValues := range query {
-		// check value-discriminant fields first
-		if _, isValueField := valueFields[optKey]; isValueField {
+	seen := make(map[string]bool)
+	for key, rawValues := range query {
+		// case 1: field is a flag set
+		if fs, ok := si.FlagSets[key]; ok {
 			for _, rawValue := range rawValues {
-				if valueField, matched := valueFields[optKey][rawValue]; matched {
-					valueField.SetBool(true)
-					continue
+				if index, ok := fs.Indexes[rawValue]; ok {
+					optsValue.FieldByIndex(index).SetBool(true)
+				} else {
+					return fmt.Errorf("unknown value %q for query parameter %q", rawValue, key)
 				}
-				return opts, fmt.Errorf("unknown value %q for query parameter %q", rawValue, optKey)
 			}
 			continue
 		}
 
-		meta, ok := knownOpts[optKey]
+		// case 2: field is an option
+		opt, ok := si.Options[key]
 		if !ok {
-			return opts, fmt.Errorf("unknown query parameter %q", optKey)
+			return fmt.Errorf("unknown query parameter %q", key)
 		}
-		err := setField(meta.structField, meta.fieldValue, rawValues, meta.maybeTimeFormat)
+		err := setField(optsValue.FieldByIndex(opt.Index), rawValues, opt.TimeFormat)
 		if err != nil {
-			return opts, fmt.Errorf("invalid value for query parameter %q: %w", optKey, err)
+			return fmt.Errorf("invalid value for query parameter %q: %w", key, err)
 		}
-		if !isOnlyEmptyStrings(rawValues) && meta.requiredAndUnseen {
-			meta.requiredAndUnseen = false
-			knownOpts[optKey] = meta
+		if !isOnlyEmptyStrings(rawValues) {
+			seen[key] = true
 		}
 	}
 
 	// check that no required fields are missing
-	for optKey, meta := range knownOpts {
-		if meta.requiredAndUnseen {
-			return opts, fmt.Errorf("missing value for query parameter %q", optKey)
+	for key, opt := range si.Options {
+		if opt.Required && !seen[key] {
+			return fmt.Errorf("missing value for query parameter %q", key)
 		}
 	}
-	return opts, nil
+	return nil
 }
 
 // isOnlyEmptyStrings checks if all rawValues are only emptyStrings.
@@ -195,7 +137,7 @@ func isOnlyEmptyStrings(rawValues []string) bool {
 
 // setField writes values into a single struct field.
 // The timeFormat parameter carries the format option from the q tag (may be empty).
-func setField(f reflect.StructField, fv reflect.Value, values []string, timeFormat Option[string]) error {
+func setField(fv reflect.Value, values []string, timeFormat Option[string]) error {
 	if len(values) == 0 {
 		return nil
 	}
@@ -217,7 +159,7 @@ func setField(f reflect.StructField, fv reflect.Value, values []string, timeForm
 			destVal := reflect.ValueOf(dest).Elem()         // *T
 			destVal.Set(reflect.New(destVal.Type().Elem())) // allocate T, set *T
 			inner := destVal.Elem()                         // T (the actual value to fill)
-			return setField(f, inner, values, timeFormat)
+			return setField(inner, values, timeFormat)
 		}
 		type yamlUnmarshaler interface {
 			UnmarshalYAML(func(any) error) error

--- a/opts/parse_test.go
+++ b/opts/parse_test.go
@@ -241,6 +241,9 @@ func TestOptParserErrors(t *testing.T) {
 		opts.ParseQueryString[int](r.URL.Query()) //nolint:errcheck // won't get to this part
 	})
 
+	// unknown value in flagset
+	checkParsingError(t, "?with=details&with=nonsense", `unknown value "nonsense" for query parameter "with"`)
+
 	// missing required parameter
 	type testStringRequiredOpts struct {
 		String string `q:"string,required"`
@@ -293,6 +296,9 @@ func TestOptParserErrors(t *testing.T) {
 	checkParsingError(t, "?uint64=foo", `invalid value for query parameter "uint64": strconv.ParseUint: parsing "foo": invalid syntax`)
 	checkParsingError(t, "?float32=foo", `invalid value for query parameter "float32": strconv.ParseFloat: parsing "foo": invalid syntax`)
 	checkParsingError(t, "?float64=foo", `invalid value for query parameter "float64": strconv.ParseFloat: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?int_slice=1&int_slice=foo", `invalid value for query parameter "int_slice": element 1: strconv.ParseInt: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?int_string_map=foo:bar", `invalid value for query parameter "int_string_map": invalid map key "foo": strconv.ParseInt: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?string_int_map=foo:bar", `invalid value for query parameter "string_int_map": invalid map value "bar": strconv.ParseInt: parsing "bar": invalid syntax`)
 
 	// wrong type: pointer of numbers
 	checkParsingError(t, "?pointer_int=foo", `invalid value for query parameter "pointer_int": strconv.ParseInt: parsing "foo": invalid syntax`)

--- a/opts/parse_test.go
+++ b/opts/parse_test.go
@@ -30,6 +30,7 @@ type testOpts struct {
 	StringIntMap      map[string]int    `q:"string_int_map"`
 	Bool              bool              `q:"bool"`
 	Time              time.Time         `q:"time,format:RFC3339"`
+	TimeUnix          time.Time         `q:"time_unix,format:Unix"`
 	String            string            `q:"string"`
 	Int               int               `q:"int"`
 	Int8              int8              `q:"int8"`
@@ -45,6 +46,7 @@ type testOpts struct {
 	Float64           float64           `q:"float64"`
 	PointerBool       *bool             `q:"pointer_bool"`
 	PointerTime       *time.Time        `q:"pointer_time,format:RFC3339"`
+	PointerTimeUnix   *time.Time        `q:"pointer_time_unix,format:Unix"`
 	PointerString     *string           `q:"pointer_string"`
 	PointerInt        *int              `q:"pointer_int"`
 	PointerInt8       *int8             `q:"pointer_int8"`
@@ -60,6 +62,7 @@ type testOpts struct {
 	PointerFloat64    *float64          `q:"pointer_float64"`
 	BoolSlice         []bool            `q:"bool_slice"`
 	TimeSlice         []time.Time       `q:"time_slice,format:RFC3339"`
+	TimeUnixSlice     []time.Time       `q:"time_unix_slice,format:Unix"`
 	StringSlice       []string          `q:"string_slice"`
 	IntSlice          []int             `q:"int_slice"`
 	Int8Slice         []int8            `q:"int8_slice"`
@@ -75,6 +78,7 @@ type testOpts struct {
 	Float64Slice      []float64         `q:"float64_slice"`
 	OptionBool        Option[bool]      `q:"option_bool"`
 	OptionTime        Option[time.Time] `q:"option_time,format:RFC3339"`
+	OptionTimeUnix    Option[time.Time] `q:"option_time_unix,format:Unix"`
 	OptionString      Option[string]    `q:"option_string"`
 	OptionInt         Option[int]       `q:"option_int"`
 	OptionInt8        Option[int8]      `q:"option_int8"`
@@ -122,10 +126,14 @@ func TestOptParserHappyPaths(t *testing.T) {
 	// time
 	checkParsingHappyPath(t, "time RFC3339", "?time=2000-01-01T00:00:00Z",
 		testOpts{Time: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)})
+	checkParsingHappyPath(t, "time Unix", "?time_unix=946684800",
+		testOpts{TimeUnix: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)})
 
 	// pointer time
 	checkParsingHappyPath(t, "pointer time RFC3339", "?pointer_time=2000-01-01T00:00:00Z",
 		testOpts{PointerTime: new(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC))})
+	checkParsingHappyPath(t, "pointer time Unix", "?pointer_time_unix=946684800",
+		testOpts{PointerTimeUnix: new(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC))})
 
 	// time slice
 	checkParsingHappyPath(t, "slice time RFC3339", "?time_slice=2000-01-01T00:00:00Z&time_slice=2001-01-01T00:00:00Z&time_slice=2002-01-01T00:00:00Z",
@@ -134,10 +142,18 @@ func TestOptParserHappyPaths(t *testing.T) {
 			time.Date(2001, 1, 1, 0, 0, 0, 0, time.UTC),
 			time.Date(2002, 1, 1, 0, 0, 0, 0, time.UTC),
 		}})
+	checkParsingHappyPath(t, "slice time Unix", "?time_unix_slice=946684800&time_unix_slice=978307200&time_unix_slice=1009843200",
+		testOpts{TimeUnixSlice: []time.Time{
+			time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC),
+			time.Date(2001, 1, 1, 0, 0, 0, 0, time.UTC),
+			time.Date(2002, 1, 1, 0, 0, 0, 0, time.UTC),
+		}})
 
 	// option time
 	checkParsingHappyPath(t, "option time RFC3339", "?option_time=2000-01-01T00:00:00Z",
 		testOpts{OptionTime: Some(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC))})
+	checkParsingHappyPath(t, "option time Unix", "?option_time_unix=946684800",
+		testOpts{OptionTimeUnix: Some(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC))})
 
 	// plain scalars
 	checkParsingHappyPath(t, "bool", "?bool=true", testOpts{Bool: true})
@@ -267,6 +283,11 @@ func TestOptParserErrors(t *testing.T) {
 	checkParsingError(t, "?pointer_time=foo", `invalid value for query parameter "pointer_time": cannot parse "foo" as RFC3339: parsing time "foo" as "2006-01-02T15:04:05Z07:00": cannot parse "foo" as "2006"`)
 	checkParsingError(t, "?time_slice=foo", `invalid value for query parameter "time_slice": element 0: cannot parse "foo" as RFC3339: parsing time "foo" as "2006-01-02T15:04:05Z07:00": cannot parse "foo" as "2006"`)
 	checkParsingError(t, "?option_time=foo", `invalid value for query parameter "option_time": cannot parse "foo" as RFC3339: parsing time "foo" as "2006-01-02T15:04:05Z07:00": cannot parse "foo" as "2006"`)
+
+	checkParsingError(t, "?time_unix=foo", `invalid value for query parameter "time_unix": cannot parse "foo" as Unix seconds: strconv.ParseInt: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?pointer_time_unix=foo", `invalid value for query parameter "pointer_time_unix": cannot parse "foo" as Unix seconds: strconv.ParseInt: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?time_unix_slice=foo", `invalid value for query parameter "time_unix_slice": element 0: cannot parse "foo" as Unix seconds: strconv.ParseInt: parsing "foo": invalid syntax`)
+	checkParsingError(t, "?option_time_unix=foo", `invalid value for query parameter "option_time_unix": cannot parse "foo" as Unix seconds: strconv.ParseInt: parsing "foo": invalid syntax`)
 
 	// multiple values: time
 	checkParsingError(t, "?time=2000-01-01&time=2001-01-01", `invalid value for query parameter "time": expected a single value, got 2`)

--- a/opts/parse_test.go
+++ b/opts/parse_test.go
@@ -258,7 +258,7 @@ func TestOptParserErrors(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/some/unimportant/path", http.NoBody)
 
 	// non-struct type parameter (panics)
-	checkParsingPanic(t, "expected opts to point to a struct", func() {
+	checkParsingPanic(t, "options type is not a struct", func() {
 		opts.ParseQueryString[int](r.URL.Query()) //nolint:errcheck // won't get to this part
 	})
 

--- a/opts/parse_test.go
+++ b/opts/parse_test.go
@@ -226,27 +226,6 @@ func TestOptParserHappyPaths(t *testing.T) {
 		testOpts{WithDetails: true, WithSubresources: false, WithSubcapacities: true})
 }
 
-func checkParsingPanic(t *testing.T, panicMsg string, fn func()) {
-	t.Helper()
-	defer func() {
-		t.Helper()
-		r := recover()
-		if r == nil {
-			t.Errorf("expected panic %q, but function did not panic", panicMsg)
-			return
-		}
-		got, ok := r.(string)
-		if !ok {
-			t.Errorf("expected panic with string %q, but got non-string panic: %v", panicMsg, r)
-			return
-		}
-		if got != panicMsg {
-			t.Errorf("expected panic: %s, but got: %s", panicMsg, got)
-		}
-	}()
-	fn()
-}
-
 func checkParsingError(t *testing.T, query, errMsg string) {
 	t.Helper()
 	r := httptest.NewRequest(http.MethodGet, "/some/unimportant/path"+query, http.NoBody)
@@ -258,35 +237,8 @@ func TestOptParserErrors(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/some/unimportant/path", http.NoBody)
 
 	// non-struct type parameter (panics)
-	checkParsingPanic(t, "options type is not a struct", func() {
+	expectPanic(t, "options type is not a struct", func() {
 		opts.ParseQueryString[int](r.URL.Query()) //nolint:errcheck // won't get to this part
-	})
-
-	// missing q-tag (panics)
-	type testNonOpts struct {
-		String string `yaml:"string"`
-	}
-	checkParsingPanic(t, `expected "String" to have a "q:"-tag`, func() {
-		opts.ParseQueryString[testNonOpts](r.URL.Query()) //nolint:errcheck // won't get to this part
-	})
-
-	// embedded struct with q-tag (panics)
-	type testEmbeddedQTagOpts struct {
-		EmbeddedOpts `q:"embedded"`
-	}
-	checkParsingPanic(t, `expected embedded struct "EmbeddedOpts" to have no "q:"-tag`, func() {
-		opts.ParseQueryString[testEmbeddedQTagOpts](r.URL.Query()) //nolint:errcheck // won't get to this part
-	})
-
-	// contradictory field declarations
-	type testFieldNameCollisionOpts struct {
-		Scope   string   `q:"scope"`
-		With    []string `q:"with"`
-		WithFoo bool     `q:"with,value:foo"`
-		WithBar bool     `q:"with,value:bar"`
-	}
-	checkParsingPanic(t, `key "with" cannot be declared as both a regular field and a value-discriminant field`, func() {
-		opts.ParseQueryString[testFieldNameCollisionOpts](r.URL.Query()) //nolint:errcheck // won't get to this part
 	})
 
 	// missing required parameter
@@ -327,18 +279,6 @@ func TestOptParserErrors(t *testing.T) {
 	// wrong time format
 	checkParsingError(t, "?time=2000-01-01", `invalid value for query parameter "time": cannot parse "2000-01-01" as RFC3339: parsing time "2000-01-01" as "2006-01-02T15:04:05Z07:00": cannot parse "" as "T"`)
 	r = httptest.NewRequest(http.MethodGet, "/some/unimportant/path?time=2000-01-01%2000:00", http.NoBody)
-	type testImpossibleTimeFormatOpts struct {
-		Time time.Time `q:"time,format:foo"`
-	}
-	checkParsingPanic(t, `unsupported time format "foo"; accepted: DateOnly, DateTime, RFC3339, RFC3339Nano, Unix`, func() {
-		opts.ParseQueryString[testImpossibleTimeFormatOpts](r.URL.Query()) //nolint:errcheck // won't get to this part
-	})
-	type testMissingTimeFormatOpts struct {
-		Time time.Time `q:"time"`
-	}
-	checkParsingPanic(t, `time format is missing for field "Time"`, func() {
-		opts.ParseQueryString[testMissingTimeFormatOpts](r.URL.Query()) //nolint:errcheck // won't get to this part
-	})
 
 	// wrong type: numbers
 	checkParsingError(t, "?int=foo", `invalid value for query parameter "int": strconv.ParseInt: parsing "foo": invalid syntax`)

--- a/opts/serialize.go
+++ b/opts/serialize.go
@@ -78,7 +78,7 @@ func BuildQueryString(opts any) (url.Values, error) {
 }
 
 // serializeValue converts a reflect.Value to its string representation for query parameters.
-// Zero values are serialized, also - so they need to be taken care of separately, if that is no intentional.
+// Zero values are serialized, also - so they need to be taken care of separately, if that is not intentional.
 func serializeValue(value reflect.Value, maybeTimeFormat Option[string]) []string {
 	// dereference pointers
 	for value.Kind() == reflect.Pointer {
@@ -124,7 +124,7 @@ func serializeValue(value reflect.Value, maybeTimeFormat Option[string]) []strin
 }
 
 // serializeSingleValue converts a reflect.Value of a primitive type (e.g. int/string, but not slice/map) to its string representation for query parameters.
-// Zero values are serialized, also - so they need to be taken care of separately, if that is no intentional.
+// Zero values are serialized, also - so they need to be taken care of separately, if that is not intentional.
 func serializeSingleValue(v reflect.Value, timeFormat Option[string]) string {
 	// Dereference pointers.
 	for v.Kind() == reflect.Pointer {

--- a/opts/serialize.go
+++ b/opts/serialize.go
@@ -105,7 +105,7 @@ func serializeValue(value reflect.Value, maybeTimeFormat Option[string]) []strin
 				return nil
 			}
 		} else {
-			// defense in depth: already handled by canBeSkipped function
+			// defense in depth: should have been rejected in checkFieldTypeAllowed()
 			panic("structs other than time.Time and option.Option[T] are not supported")
 		}
 	case reflect.Map:
@@ -172,11 +172,6 @@ func serializeSingleValue(v reflect.Value, timeFormat Option[string]) string {
 // - structs (only time.Time and Option[T] are supported; others panic)
 // - pointers (nil means skippable)
 func canBeSkipped(v reflect.Value, required bool) bool {
-	// reject functions
-	if v.Kind() == reflect.Func {
-		panic("functions are not supported")
-	}
-
 	if required {
 		return false
 	}
@@ -199,6 +194,7 @@ func canBeSkipped(v reflect.Value, required bool) bool {
 			type isZeroer interface{ IsZero() bool }
 			return v.Interface().(isZeroer).IsZero()
 		}
+		// defense in depth: should have been rejected in checkFieldTypeAllowed()
 		panic("structs other than time.Time and option.Option[T] are not supported")
 	}
 

--- a/opts/serialize.go
+++ b/opts/serialize.go
@@ -43,136 +43,94 @@ import (
 // [gophercloud.BuildQueryString]: https://pkg.go.dev/github.com/gophercloud/gophercloud/v2#BuildQueryString
 func BuildQueryString(opts any) (url.Values, error) {
 	optsValue := reflect.ValueOf(opts)
-	if optsValue.Kind() == reflect.Pointer {
+	for optsValue.Kind() == reflect.Pointer {
 		if optsValue.IsNil() {
 			panic("opts is a nil pointer")
 		}
 		optsValue = optsValue.Elem()
 	}
-	optsType := optsValue.Type()
+	si := getStructInfo(optsValue.Type())
 	params := url.Values{}
 
-	if optsValue.Kind() != reflect.Struct {
-		panic("options type is not a struct")
+	// serialize flagsets
+	for key, fs := range si.FlagSets {
+		for value, index := range fs.Indexes {
+			if optsValue.FieldByIndex(index).Bool() {
+				params.Add(key, value)
+			}
+		}
+		slices.Sort(params[key])
 	}
 
-	// Collect value-discriminant fields (bool fields with "value:" option) separately.
-	type valueField struct {
-		fieldValue reflect.Value
-		value      string
-	}
-	isRegularQueryField := make(map[string]bool) // tracks fields that are not value-discriminant field (for checking field name collisions)
-	valueDiscriminantFields := make(map[string][]valueField)
-
-	for _, field := range reflect.VisibleFields(optsType) {
-		fieldValue := optsValue.FieldByIndex(field.Index)
-		qTag := field.Tag.Get("q")
-		if field.Anonymous {
-			// this is for struct embedding to work
-			if qTag != "" {
-				panic(fmt.Sprintf(`expected embedded struct %q to have no "q:"-tag`, field.Name))
-			}
+	// serialize options
+	for key, opt := range si.Options {
+		value := optsValue.FieldByIndex(opt.Index)
+		if canBeSkipped(value, opt.Required) {
 			continue
 		}
-		if qTag == "" {
-			panic(fmt.Sprintf(`expected %q to have a "q:"-tag`, field.Name))
-		}
-		if !fieldValue.CanInterface() {
-			panic(fmt.Sprintf(`field %q is unexported and therefore cannot be read`, field.Name))
-		}
-		key, maybeTimeFormat, maybeValue, required := parseQTag(qTag)
-
-		// check if format is set when required
-		if typeNeedsTimeFormat(fieldValue.Type()) && maybeTimeFormat.IsNone() {
-			panic(fmt.Sprintf(`time format is missing for field %q`, field.Name))
-		}
-
-		// value-discriminant fields: collect and skip normal processing
-		if value, ok := maybeValue.Unpack(); ok {
-			if isRegularQueryField[key] {
-				panic(fmt.Sprintf(`key %q cannot be declared as both a regular field and a value-discriminant field`, key))
-			}
-			if fieldValue.Kind() != reflect.Bool {
-				panic(fmt.Sprintf(`field %q has "value:" option but is not a bool`, field.Name))
-			}
-			valueDiscriminantFields[key] = append(valueDiscriminantFields[key], valueField{
-				fieldValue: fieldValue,
-				value:      value,
-			})
-			continue
-		}
-
-		// check collision between normal and value-discriminant fields
-		isRegularQueryField[key] = true
-		if _, exists := valueDiscriminantFields[key]; exists {
-			panic(fmt.Sprintf(`key %q cannot be declared as both a regular field and a value-discriminant field`, key))
-		}
-
-		// if field not set, skip
-		if canBeSkipped(fieldValue, required) {
-			continue
-		}
-	loop:
-		switch fieldValue.Kind() {
-		case reflect.Pointer:
-			fieldValue = fieldValue.Elem()
-			goto loop
-		// only handle non-single-values here, rest is done by serializeSingleValue()
-		case reflect.Slice:
-			values := make([]string, fieldValue.Len())
-			for i := range fieldValue.Len() {
-				values[i] = serializeSingleValue(fieldValue.Index(i), maybeTimeFormat)
-			}
-			params[key] = append(params[key], values...)
-		case reflect.Struct:
-			if fieldValue.Type() == reflect.TypeFor[time.Time]() {
-				params.Add(key, serializeSingleValue(fieldValue, maybeTimeFormat))
-			} else if m := fieldValue.MethodByName("AsPointer"); m.IsValid() {
-				// Option[T] — unwrap via AsPointer
-				results := m.Call(nil)
-				if len(results) == 1 && results[0].Kind() == reflect.Pointer && !results[0].IsNil() {
-					params.Add(key, serializeSingleValue(results[0].Elem(), maybeTimeFormat))
-				}
-			} else {
-				// defense in depth: already handled by canBeSkipped function
-				panic("structs other than time.Time and option.Option[T] are not supported")
-			}
-		case reflect.Map:
-			keys := fieldValue.MapKeys()
-			slices.SortFunc(keys, func(a, b reflect.Value) int {
-				return strings.Compare(serializeSingleValue(a, maybeTimeFormat), serializeSingleValue(b, maybeTimeFormat))
-			})
-			for _, k := range keys {
-				params.Add(key, serializeSingleValue(k, maybeTimeFormat)+":"+serializeSingleValue(fieldValue.MapIndex(k), maybeTimeFormat))
-			}
-		default:
-			params.Add(key, serializeSingleValue(fieldValue, maybeTimeFormat))
-		}
-		if required && isOnlyEmptyStrings(params[key]) {
+		params[key] = serializeValue(value, opt.TimeFormat)
+		if opt.Required && isOnlyEmptyStrings(params[key]) {
 			// if the field is required, it cannot have no value (handles nil maps, slices, arrays)
-			return url.Values{}, fmt.Errorf("required query parameter [%s] not set", field.Name)
+			return url.Values{}, fmt.Errorf("required query parameter %q not set", key)
 		}
 	}
-
-	// Serialize value-discriminant fields: true bools emit their value string.
-	for key, vfs := range valueDiscriminantFields {
-		for _, vf := range vfs {
-			if vf.fieldValue.Bool() {
-				params.Add(key, vf.value)
-			}
-		}
-	}
-
 	return params, nil
 }
 
-// serializeSingleValue converts a reflect.Value to its string representation for query parameters.
+// serializeValue converts a reflect.Value to its string representation for query parameters.
+// Zero values are serialized, also - so they need to be taken care of separately, if that is no intentional.
+func serializeValue(value reflect.Value, maybeTimeFormat Option[string]) []string {
+	// dereference pointers
+	for value.Kind() == reflect.Pointer {
+		value = value.Elem()
+	}
+
+	// only handle non-single-values here, rest is done by serializeSingleValue()
+	switch value.Kind() {
+	case reflect.Slice:
+		values := make([]string, value.Len())
+		for i := range value.Len() {
+			values[i] = serializeSingleValue(value.Index(i), maybeTimeFormat)
+		}
+		return values
+	case reflect.Struct:
+		if value.Type() == reflect.TypeFor[time.Time]() {
+			return []string{serializeSingleValue(value, maybeTimeFormat)}
+		} else if m := value.MethodByName("AsPointer"); m.IsValid() {
+			// Option[T] — unwrap via AsPointer
+			results := m.Call(nil)
+			if len(results) == 1 && results[0].Kind() == reflect.Pointer && !results[0].IsNil() {
+				return []string{serializeSingleValue(results[0].Elem(), maybeTimeFormat)}
+			} else {
+				return nil
+			}
+		} else {
+			// defense in depth: already handled by canBeSkipped function
+			panic("structs other than time.Time and option.Option[T] are not supported")
+		}
+	case reflect.Map:
+		keys := value.MapKeys()
+		slices.SortFunc(keys, func(a, b reflect.Value) int {
+			return strings.Compare(serializeSingleValue(a, maybeTimeFormat), serializeSingleValue(b, maybeTimeFormat))
+		})
+		result := make([]string, 0, value.Len())
+		for _, k := range keys {
+			result = append(result, serializeSingleValue(k, maybeTimeFormat)+":"+serializeSingleValue(value.MapIndex(k), maybeTimeFormat))
+		}
+		return result
+	default:
+		return []string{serializeSingleValue(value, maybeTimeFormat)}
+	}
+}
+
+// serializeSingleValue converts a reflect.Value of a primitive type (e.g. int/string, but not slice/map) to its string representation for query parameters.
 // Zero values are serialized, also - so they need to be taken care of separately, if that is no intentional.
 func serializeSingleValue(v reflect.Value, timeFormat Option[string]) string {
 	// Dereference pointers.
 	for v.Kind() == reflect.Pointer {
 		v = v.Elem()
 	}
+
 	switch v.Kind() {
 	case reflect.String:
 		return v.String()

--- a/opts/serialize_test.go
+++ b/opts/serialize_test.go
@@ -254,5 +254,5 @@ func TestBuildQueryStringErrors(t *testing.T) {
 		Name string `q:"name,required"`
 	}
 	_, err := opts.BuildQueryString(requiredOpts{})
-	th.AssertErr(t, "required query parameter [Name] not set", err)
+	th.AssertErr(t, `required query parameter "name" not set`, err)
 }

--- a/opts/serialize_test.go
+++ b/opts/serialize_test.go
@@ -157,97 +157,19 @@ func TestBuildQueryStringHappyPaths(t *testing.T) {
 		"with=details&with=subcapacities")
 }
 
-func checkSerializingPanic(t *testing.T, panicMsg string, fn func()) {
-	t.Helper()
-	defer func() {
-		r := recover()
-		if r == nil {
-			t.Errorf("expected panic %q, but function did not panic", panicMsg)
-			return
-		}
-		got, ok := r.(string)
-		if !ok {
-			t.Errorf("expected panic with string %q, but got non-string panic: %v", panicMsg, r)
-			return
-		}
-		if got != panicMsg {
-			t.Errorf("expected panic: %s, but got: %s", panicMsg, got)
-		}
-	}()
-	fn()
+func expectSerializingPanic(t *testing.T, data any, panicMsg string) {
+	expectPanic(t, panicMsg, func() {
+		t.Helper()
+		_, _ = opts.BuildQueryString(data) //nolint:errcheck // panics before returning
+	})
 }
 
 func TestBuildQueryStringErrors(t *testing.T) {
 	// nil-pointer input (panics)
-	checkSerializingPanic(t, "opts is a nil pointer", func() {
-		opts.BuildQueryString((*testOpts)(nil)) //nolint:errcheck // won't get to this part
-	})
+	expectSerializingPanic(t, (*testOpts)(nil), "opts is a nil pointer")
 
 	// non-struct input (panics)
-	checkSerializingPanic(t, "options type is not a struct", func() {
-		opts.BuildQueryString(42) //nolint:errcheck // won't get to this part
-	})
-
-	// missing q-tag (panics)
-	type testNonOpts struct {
-		String string `yaml:"string"`
-	}
-	checkSerializingPanic(t, `expected "String" to have a "q:"-tag`, func() {
-		opts.BuildQueryString(testNonOpts{}) //nolint:errcheck // won't get to this part
-	})
-
-	// embedded struct with q-tag (panics)
-	type testEmbeddedQTagOpts struct {
-		EmbeddedOpts `q:"embedded"`
-	}
-	checkSerializingPanic(t, `expected embedded struct "EmbeddedOpts" to have no "q:"-tag`, func() {
-		opts.BuildQueryString(testEmbeddedQTagOpts{}) //nolint:errcheck // won't get to this part
-	})
-
-	// contradictory field declarations
-	type testFieldNameCollisionOpts struct {
-		Scope   string   `q:"scope"`
-		With    []string `q:"with"`
-		WithFoo bool     `q:"with,value:foo"`
-		WithBar bool     `q:"with,value:bar"`
-	}
-	checkParsingPanic(t, `key "with" cannot be declared as both a regular field and a value-discriminant field`, func() {
-		opts.BuildQueryString(testFieldNameCollisionOpts{}) //nolint:errcheck // won't get to this part
-	})
-	type testFieldNameCollisionOptsFlipped struct {
-		Scope   string   `q:"scope"`
-		WithFoo bool     `q:"with,value:foo"`
-		WithBar bool     `q:"with,value:bar"`
-		With    []string `q:"with"`
-	}
-	checkParsingPanic(t, `key "with" cannot be declared as both a regular field and a value-discriminant field`, func() {
-		opts.BuildQueryString(testFieldNameCollisionOptsFlipped{}) //nolint:errcheck // won't get to this part
-	})
-
-	// unknown struct parameter (panics)
-	type testNested struct {
-		String string `q:"string"`
-	}
-	type testNested2 struct {
-		Nested testNested `q:"nested"`
-	}
-	checkSerializingPanic(t, "structs other than time.Time and option.Option[T] are not supported", func() {
-		opts.BuildQueryString(testNested2{}) //nolint:errcheck // won't get to this part
-	})
-
-	// unknown time format (panics)
-	type testBadTimeFormatOpts struct {
-		Time time.Time `q:"time,format:foo"`
-	}
-	checkSerializingPanic(t, `unsupported time format "foo"; accepted: DateOnly, DateTime, RFC3339, RFC3339Nano, Unix`, func() {
-		opts.BuildQueryString(testBadTimeFormatOpts{}) //nolint:errcheck // won't get to this part
-	})
-	type testMissingTimeFormatOpts struct {
-		Time time.Time `q:"time"`
-	}
-	checkSerializingPanic(t, `time format is missing for field "Time"`, func() {
-		opts.BuildQueryString(testMissingTimeFormatOpts{}) //nolint:errcheck // won't get to this part
-	})
+	expectSerializingPanic(t, 42, "options type is not a struct")
 
 	//  missing required parameter
 	type requiredOpts struct {

--- a/opts/util.go
+++ b/opts/util.go
@@ -89,3 +89,14 @@ func typeNeedsTimeFormat(t reflect.Type) bool {
 	}
 	return false
 }
+
+func isScalarFieldType(t reflect.Type) bool {
+	switch t.Kind() {
+	case reflect.String, reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Bool, reflect.Float32, reflect.Float64:
+		return true
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
This also adds the missing validation passes that the robot pointed out in #91.

While working on this, I fixed some cases where BuildQueryString and ParseQueryString are inconsistent in what datatypes they accept (e.g. BuildQueryString can serialize `[]Option[string]`, but ParseQueryString is not able to parse into this type). I have fixed those cases by restricting the shared analysis step appropriately.