### PR TITLE
limes, liquid: add UnitPiece

### DIFF
--- a/internal/units/amount.go
+++ b/internal/units/amount.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 )
 
+// TODO: BaseUnitNone, UnitNone, EmptyFormat and NumberOnlyFormat can be removed when removing support for Limes v1 (after checking that no liquids use UnitNone anymore, see TODO in liquid/validation.go)
+
 // Amount describes an amount of a countable or measurable resource in terms of a base unit.
 // This type provides basic serialization and deserialization for unit or amount strings,
 // e.g. between "1 KiB" and Amount{"B", 1024}.
@@ -23,7 +25,12 @@ type BaseUnit string
 
 const (
 	// BaseUnitNone is used for countable (rather than measurable) resources.
+	//
+	// This only exists for backwards compatibility with Limes v1 and earlier versions of the LIQUID API.
+	// Updated LIQUID implementations as well as the Limes v2 API use units derived from [BaseUnitPiece] instead.
 	BaseUnitNone BaseUnit = ""
+	// BaseUnitPiece is used for countable (rather than measurable) resources.
+	BaseUnitPiece BaseUnit = "piece"
 	// BaseUnitBytes is used for resources that are measured in bytes or any multiple thereof.
 	BaseUnitBytes BaseUnit = "B"
 )
@@ -47,7 +54,8 @@ var bareUnitDefs = []struct {
 	Symbol string
 	Amount Amount
 }{
-	// the algorithm in String() relies on this list being sorted in descending order of amount
+	{"piece", Amount{BaseUnitPiece, 1}},
+	// the algorithm in Amount.Format() relies on entries in this list for the same base unit being sorted in descending order of amount
 	{"EiB", Amount{BaseUnitBytes, 1 << 60}},
 	{"PiB", Amount{BaseUnitBytes, 1 << 50}},
 	{"TiB", Amount{BaseUnitBytes, 1 << 40}},
@@ -184,7 +192,7 @@ func (a Amount) Format(formats Format) string {
 
 // Description formats this set of formats as a description for use in error messages:
 //
-//	desc, _ := (units.UnitOnlyFormat | unit.NumberWithUnitFormat).String()
+//	desc, _ := (units.UnitOnlyFormat | unit.NumberWithUnitFormat).Description()
 //	fmt.Println(desc) // prints: "<unit>" or "<number> <unit>"
 func (f Format) Description() (output string, multipleFormats bool) {
 	parts := make([]string, 0, 4)

--- a/internal/units/unit.go
+++ b/internal/units/unit.go
@@ -17,6 +17,8 @@ type Unit struct {
 var (
 	// UnitNone is used for countable (rather than measurable) resources.
 	//
+	// This only exists for backwards compatibility with Limes v1 and earlier versions of the LIQUID API.
+	// Updated LIQUID implementations as well as the Limes v2 API use [UnitPiece] in place of UnitNone.
 	UnitNone = Unit{
 		amount: Amount{Base: BaseUnitNone, Factor: 0},
 		// ^ NOTE: Factor = 0 does not make sense, it should be 1 (as in `realUnitNone` below).
@@ -26,6 +28,17 @@ var (
 	}
 	realUnitNone = Unit{
 		amount: Amount{Base: BaseUnitNone, Factor: 1},
+	}
+
+	// UnitPiece is used for countable (rather than measurable) resources.
+	// It differs from UnitNone in that it never has an empty serialization, and thus can be multiplied safely:
+	//
+	//		UnitPiece.String()               // "piece"
+	//		UnitPiece.MultiplyBy(2).String() // "2 piece"
+	//		UnitNone.String()                // ""
+	//		UnitNone.MultiplyBy(2).String()  // "2 "!? (MultiplyBy panics to prevent this situation)
+	UnitPiece = Unit{
+		amount: Amount{Base: BaseUnitPiece, Factor: 1},
 	}
 
 	// UnitBytes is exactly that.

--- a/internal/units/unit_test.go
+++ b/internal/units/unit_test.go
@@ -39,6 +39,8 @@ func TestParseUnit(t *testing.T) {
 	}
 
 	test("", UnitNone)
+	test("piece", UnitPiece)
+	test("1000 piece", mustMultiply(UnitPiece, 1000))
 	test("KiB", UnitKibibytes)
 	test("1000 B", mustMultiply(UnitBytes, 1000))
 	test("1024 B", UnitKibibytes)
@@ -63,6 +65,8 @@ func TestSerializeUnit(t *testing.T) {
 	}
 
 	test(UnitNone, "")
+	test(UnitPiece, "piece")
+	test(mustMultiply(UnitPiece, 1000), "1000 piece")
 	test(UnitKibibytes, "KiB")
 	test(mustMultiply(UnitBytes, 1000), "1000 B")
 	test(mustMultiply(UnitBytes, 1024), "KiB")
@@ -75,13 +79,11 @@ func TestUnitMultiplyBy(t *testing.T) {
 	// This test checks some interesting corner cases.
 
 	// multiply by 1 produces exactly equal instances
-	u, err := UnitBytes.MultiplyBy(1)
-	th.AssertNoErr(t, err)
-	th.CheckDeepEquals(t, UnitBytes, u)
-
-	u, err = UnitGibibytes.MultiplyBy(1)
-	th.AssertNoErr(t, err)
-	th.CheckDeepEquals(t, UnitGibibytes, u)
+	for _, base := range []Unit{UnitPiece, UnitBytes, UnitGibibytes} {
+		u, err := base.MultiplyBy(1)
+		th.AssertNoErr(t, err)
+		th.CheckDeepEquals(t, base, u)
+	}
 }
 
 func mustMultiply(unit Unit, factor uint64) Unit {

--- a/limes/resources/overrides.go
+++ b/limes/resources/overrides.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/sapcc/go-api-declarations/limes"
+	"github.com/sapcc/go-api-declarations/liquid"
 )
 
 // ParseQuotaOverrides parses the contents of a quota-overrides.json file.
@@ -51,7 +52,7 @@ func ParseQuotaOverrides(buf []byte, getUnit func(limes.ServiceType, ResourceNam
 
 func parseSingleQuotaOverrideValue(input json.RawMessage, serviceType limes.ServiceType, resourceName ResourceName, unit limes.Unit) (uint64, error) {
 	// case 1: counted resources represent quota as a single number
-	if unit == limes.UnitNone {
+	if unit == limes.UnitNone || unit == liquid.UnitPiece {
 		var value uint64
 		err := json.Unmarshal([]byte(input), &value)
 		if err != nil {

--- a/limes/resources/overrides_test.go
+++ b/limes/resources/overrides_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/sapcc/go-api-declarations/limes"
+	"github.com/sapcc/go-api-declarations/liquid"
 )
 
 func TestParseQuotaOverrides(t *testing.T) {
@@ -20,7 +21,9 @@ func TestParseQuotaOverrides(t *testing.T) {
 		case "unittest/capacity":
 			return limes.UnitBytes, nil
 		case "unittest/things":
-			return limes.UnitNone, nil
+			// For full realism, this must return UnitPiece instead of UnitNone.
+			// Under productive use, getUnit will take metadata from the Limes DB, where UnitNone is normalized into UnitPiece.
+			return liquid.UnitPiece, nil
 		default:
 			return limes.UnitNone, fmt.Errorf("%s/%s is not a valid resource", serviceType, resourceName)
 		}

--- a/liquid/info.go
+++ b/liquid/info.go
@@ -174,7 +174,11 @@ type Unit = units.Unit
 
 var (
 	// UnitNone is used for countable (rather than measurable) resources or rates.
+	//
+	// Deprecated: Use [UnitPiece] instead. It has exactly the same meaning within Limes, and merely serializes differently.
 	UnitNone = units.UnitNone
+	// UnitPiece is used for countable (rather than measurable) resources or rates.
+	UnitPiece = units.UnitPiece
 
 	// UnitBytes is exactly that. Its MultiplyBy() method can be used to instantiate non-standard units.
 	UnitBytes = units.UnitBytes

--- a/liquid/validation.go
+++ b/liquid/validation.go
@@ -57,6 +57,7 @@ func validateServiceInfoImpl(srv ServiceInfo) (errs errorset.ErrorSet) {
 		if _, ok := srv.Categories[category]; hasCategory && !ok {
 			errs.Addf(".Resources[%q] has category %q, which is not declared in .Categories", resName, category)
 		}
+		// TODO: before removing UnitNone from internal/units, have a check here for a while that `res.Unit != units.UnitNone`
 	}
 
 	for _, rateName := range slices.Sorted(maps.Keys(srv.Rates)) {


### PR DESCRIPTION
UnitNone has weird corner cases regarding ValueWithUnit serialization, which is why we need to forbid UnitNone.MultiplyBy(). To make everything more consistent, UnitPiece is introduced as a unit that serves the same purpose as UnitNone, while having a non-empty unit name in serializations.

The migration path looks as follows:

- The Limes v1 API uses UnitNone for backwards-compatibility, so no `UnitPiece` symbol is added there.
- The LIQUID API switches to UnitPiece, but Limes will initially accept ResourceInfo/RateInfo instances using UnitNone, and rewrite those into UnitPiece at ingestion time, i.e. UnitPiece replaces UnitNone within the Limes DB. After a while, we will add a validation forbidding UnitNone at ingestion time to prepare for its removal from the API.
- The Limes v2 API will only use UnitPiece and not UnitNone. This will be easy to accomplish because units only appear in InfoReports rendered by Limes, which (as aforementioned) only uses UnitPiece in its DB records.

Please review this in tandem with https://github.com/sapcc/limes/pull/902. Once this PR is merged, we should merge the other PR quickly afterwards.