### PR TITLE
bump gg to 1.10.0, replace testhelper functions with gg/assert

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/sapcc/go-api-declarations
 
 go 1.26
 
-require go.xyrillian.de/gg v1.9.1
+require go.xyrillian.de/gg v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-go.xyrillian.de/gg v1.9.1 h1:PzB9Dn6YQmDu5pkJCEcncnCS1ddJ/fVqzMqwLBdjuOQ=
-go.xyrillian.de/gg v1.9.1/go.mod h1:dj+ZhCwC6JKWyFvImhVNXQAErrRcYMUkXu6vwWYNrzQ=
+go.xyrillian.de/gg v1.10.0 h1:Z//KSrZ9LM8ZWp1/e+4wBTuxMQlAROrSrgboMUXj3Aw=
+go.xyrillian.de/gg v1.10.0/go.mod h1:DoO4fQSWIrBRlNlCjVyrYM0kAEBt/Jg2GkMH+cGRZ0k=

--- a/internal/testhelper/testhelper.go
+++ b/internal/testhelper/testhelper.go
@@ -11,44 +11,6 @@ import (
 	"testing"
 )
 
-// AssertNoErr fails the test if the provided error is not nil.
-func AssertNoErr(t *testing.T, err error) {
-	t.Helper()
-	if err != nil {
-		t.Errorf("unexpected error: %s", err.Error())
-	}
-}
-
-// AssertErr fails the test if the provided error is nil.
-func AssertErr(t *testing.T, expected string, actual error) {
-	t.Helper()
-	switch {
-	case actual == nil:
-		t.Errorf("expected error %q, but got no error", expected)
-	case actual.Error() != expected:
-		t.Errorf("expected error: %s", expected)
-		t.Errorf(" but got error: %s", actual.Error())
-	}
-}
-
-// CheckEquals fails the test if a simple equal check between expected and actual fails.
-func CheckEquals[V comparable](t *testing.T, expected, actual V) {
-	t.Helper()
-	if expected != actual {
-		t.Errorf("expected value: %#v", expected)
-		t.Errorf(" but got value: %#v", actual)
-	}
-}
-
-// CheckDeepEquals fails the test if a reflect.DeepEqual check between expected and actual fails.
-func CheckDeepEquals(t *testing.T, expected, actual any) {
-	t.Helper()
-	if !reflect.DeepEqual(expected, actual) {
-		t.Errorf("expected value: %#v", expected)
-		t.Errorf(" but got value: %#v", actual)
-	}
-}
-
 // CheckJSONEquals fails the test if a reflect.DeepEqual check between the marshalled actual value
 // and the expectedJSON fails.
 func CheckJSONEquals(t *testing.T, expectedJSON string, actual any) {

--- a/internal/units/limesv1_test.go
+++ b/internal/units/limesv1_test.go
@@ -6,7 +6,7 @@ package units
 import (
 	"testing"
 
-	th "github.com/sapcc/go-api-declarations/internal/testhelper"
+	"go.xyrillian.de/gg/assert"
 )
 
 func TestParseInUnit(t *testing.T) {
@@ -14,25 +14,25 @@ func TestParseInUnit(t *testing.T) {
 	// Since ParseInUnit() calls ConvertTo(), this also provides coverage for ConvertTo().
 
 	value, err := ParseInUnit(UnitMebibytes, "10 MiB")
-	th.AssertNoErr(t, err)
-	th.CheckEquals(t, 10, value)
+	assert.ErrEqual(t, err, nil)
+	assert.Equal(t, value, 10)
 
 	value, err = ParseInUnit(UnitMebibytes, "10 GiB")
-	th.AssertNoErr(t, err)
-	th.CheckEquals(t, 10240, value)
+	assert.ErrEqual(t, err, nil)
+	assert.Equal(t, value, 10240)
 
 	_, err = ParseInUnit(UnitMebibytes, "10 KiB")
-	th.AssertErr(t, `value "10 KiB" cannot be represented as integer number of MiB`, err)
+	assert.ErrEqual(t, err, `value "10 KiB" cannot be represented as integer number of MiB`)
 
 	_, err = ParseInUnit(UnitMebibytes, "10")
-	th.AssertErr(t, `cannot convert value "10" to MiB because units are incompatible`, err)
+	assert.ErrEqual(t, err, `cannot convert value "10" to MiB because units are incompatible`)
 
 	value, err = ParseInUnit(UnitNone, "42")
-	th.AssertNoErr(t, err)
-	th.CheckEquals(t, 42, value)
+	assert.ErrEqual(t, err, nil)
+	assert.Equal(t, value, 42)
 
 	_, err = ParseInUnit(UnitNone, "42 MiB")
-	th.AssertErr(t, `cannot convert value "42 MiB" to <count> because units are incompatible`, err)
+	assert.ErrEqual(t, err, `cannot convert value "42 MiB" to <count> because units are incompatible`)
 }
 
 func TestValueWithUnitToString(t *testing.T) {
@@ -42,25 +42,25 @@ func TestValueWithUnitToString(t *testing.T) {
 		Value: 128,
 		Unit:  UnitKibibytes,
 	}
-	th.CheckEquals(t, "128 KiB", v.String())
+	assert.Equal(t, v.String(), "128 KiB")
 
 	v = LimesV1ValueWithUnit{
 		Value: 128,
 		Unit:  mustMultiply(UnitKibibytes, 32),
 	}
-	th.CheckEquals(t, "4 MiB", v.String()) // uses nice formatting, i.e. neither "128 x 32 KiB" nor "4096 KiB"
+	assert.Equal(t, v.String(), "4 MiB") // uses nice formatting, i.e. neither "128 x 32 KiB" nor "4096 KiB"
 
 	v = LimesV1ValueWithUnit{
 		// this value is equal to 2^75 bytes and overflows type Amount
 		Value: 32768,
 		Unit:  UnitExbibytes,
 	}
-	th.CheckEquals(t, "32768 EiB", v.String()) // printed via fallback logic
+	assert.Equal(t, v.String(), "32768 EiB") // printed via fallback logic
 
 	v = LimesV1ValueWithUnit{
 		// same value, but this time the fallback printing logic is more obvious
 		Value: 16384,
 		Unit:  mustMultiply(UnitExbibytes, 2),
 	}
-	th.CheckEquals(t, "16384 x 2 EiB", v.String())
+	assert.Equal(t, v.String(), "16384 x 2 EiB")
 }

--- a/internal/units/unit_test.go
+++ b/internal/units/unit_test.go
@@ -4,11 +4,12 @@
 package units
 
 import (
+	"database/sql/driver"
 	"encoding/json"
 	"fmt"
 	"testing"
 
-	th "github.com/sapcc/go-api-declarations/internal/testhelper"
+	"go.xyrillian.de/gg/assert"
 )
 
 func TestParseUnit(t *testing.T) {
@@ -19,22 +20,22 @@ func TestParseUnit(t *testing.T) {
 			// test parsing from SQL string
 			var u1 Unit
 			err := u1.Scan(input)
-			th.AssertNoErr(t, err)
-			th.CheckDeepEquals(t, expected, u1)
+			assert.ErrEqual(t, err, nil)
+			assert.Equal(t, u1, expected)
 
 			// test parsing from SQL bytestring
 			var u2 Unit
 			err = u2.Scan([]byte(input))
-			th.AssertNoErr(t, err)
-			th.CheckDeepEquals(t, expected, u2)
+			assert.ErrEqual(t, err, nil)
+			assert.Equal(t, u2, expected)
 
 			// test parsing from JSON string
 			buf, err := json.Marshal(input)
-			th.AssertNoErr(t, err)
+			assert.ErrEqual(t, err, nil)
 			var u3 Unit
 			err = json.Unmarshal(buf, &u3)
-			th.AssertNoErr(t, err)
-			th.CheckDeepEquals(t, expected, u3)
+			assert.ErrEqual(t, err, nil)
+			assert.Equal(t, u3, expected)
 		})
 	}
 
@@ -50,17 +51,17 @@ func TestSerializeUnit(t *testing.T) {
 	test := func(unit Unit, expected string) {
 		t.Run(fmt.Sprintf("%#v", unit), func(t *testing.T) {
 			// test serialization through fmt.Stringer
-			th.CheckDeepEquals(t, expected, unit.String())
+			assert.Equal(t, unit.String(), expected)
 
 			// test serialization as SQL string
 			value, err := unit.Value()
-			th.AssertNoErr(t, err)
-			th.CheckDeepEquals(t, expected, value)
+			assert.ErrEqual(t, err, nil)
+			assert.Equal(t, value, driver.Value(expected))
 
 			// test serialization as JSON string
 			buf, err := json.Marshal(unit)
-			th.AssertNoErr(t, err)
-			th.CheckDeepEquals(t, fmt.Sprintf("%q", expected), string(buf))
+			assert.ErrEqual(t, err, nil)
+			assert.Equal(t, string(buf), fmt.Sprintf("%q", expected))
 		})
 	}
 
@@ -81,8 +82,8 @@ func TestUnitMultiplyBy(t *testing.T) {
 	// multiply by 1 produces exactly equal instances
 	for _, base := range []Unit{UnitPiece, UnitBytes, UnitGibibytes} {
 		u, err := base.MultiplyBy(1)
-		th.AssertNoErr(t, err)
-		th.CheckDeepEquals(t, base, u)
+		assert.ErrEqual(t, err, nil)
+		assert.Equal(t, u, base)
 	}
 }
 

--- a/limes/rates/input_test.go
+++ b/limes/rates/input_test.go
@@ -6,6 +6,8 @@ package limesrates
 import (
 	"testing"
 
+	"go.xyrillian.de/gg/assert"
+
 	th "github.com/sapcc/go-api-declarations/internal/testhelper"
 )
 
@@ -43,6 +45,6 @@ func TestQuotaRateLimitMarshal(t *testing.T) {
 func TestRateLimitRequestUnmarshal(t *testing.T) {
 	var actual RateRequest
 	err := actual.UnmarshalJSON([]byte(rateLimitJSON))
-	th.AssertNoErr(t, err)
-	th.CheckDeepEquals(t, rateLimits, actual)
+	assert.ErrEqual(t, err, nil)
+	assert.Equal(t, actual, rateLimits)
 }

--- a/limes/rates/report_cluster_test.go
+++ b/limes/rates/report_cluster_test.go
@@ -6,6 +6,8 @@ package limesrates
 import (
 	"testing"
 
+	"go.xyrillian.de/gg/assert"
+
 	th "github.com/sapcc/go-api-declarations/internal/testhelper"
 	"github.com/sapcc/go-api-declarations/limes"
 )
@@ -49,6 +51,6 @@ func TestClusterServicesOnlyRatesMarshal(t *testing.T) {
 func TestClusterServicesOnlyRatesUnmarshal(t *testing.T) {
 	actual := &ClusterServiceReports{}
 	err := actual.UnmarshalJSON([]byte(clusterServicesOnlyRatesMockJSON))
-	th.AssertNoErr(t, err)
-	th.CheckDeepEquals(t, clusterServicesOnlyRates, actual)
+	assert.ErrEqual(t, err, nil)
+	assert.Equal(t, actual, clusterServicesOnlyRates)
 }

--- a/limes/rates/report_project_test.go
+++ b/limes/rates/report_project_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"go.xyrillian.de/gg/assert"
+
 	th "github.com/sapcc/go-api-declarations/internal/testhelper"
 	"github.com/sapcc/go-api-declarations/limes"
 )
@@ -138,8 +140,8 @@ func TestProjectServicesRateLimitMarshall(t *testing.T) {
 func TestProjectServicesRateLimitUnmarshall(t *testing.T) {
 	actual := &ProjectServiceReports{}
 	err := actual.UnmarshalJSON([]byte(projectServicesRateLimitMockJSON))
-	th.AssertNoErr(t, err)
-	th.CheckDeepEquals(t, projectMockServicesRateLimit, actual)
+	assert.ErrEqual(t, err, nil)
+	assert.Equal(t, actual, projectMockServicesRateLimit)
 }
 
 func TestProjectServicesRateLimitDeviatingFromDefaultsMarshall(t *testing.T) {
@@ -149,8 +151,8 @@ func TestProjectServicesRateLimitDeviatingFromDefaultsMarshall(t *testing.T) {
 func TestProjectServicesRateLimitDeviatingFromDefaultsUnmarshall(t *testing.T) {
 	actual := &ProjectServiceReports{}
 	err := actual.UnmarshalJSON([]byte(projectServicesRateLimitDeviatingFromDefaultsMockJSON))
-	th.AssertNoErr(t, err)
-	th.CheckDeepEquals(t, projectMockServicesRateLimitDeviatingFromDefaults, actual)
+	assert.ErrEqual(t, err, nil)
+	assert.Equal(t, actual, projectMockServicesRateLimitDeviatingFromDefaults)
 }
 
 func p2time(timestamp int64) *limes.UnixEncodedTime {

--- a/limes/resources/report_cluster_test.go
+++ b/limes/resources/report_cluster_test.go
@@ -6,6 +6,8 @@ package limesresources
 import (
 	"testing"
 
+	"go.xyrillian.de/gg/assert"
+
 	th "github.com/sapcc/go-api-declarations/internal/testhelper"
 	"github.com/sapcc/go-api-declarations/limes"
 )
@@ -162,8 +164,8 @@ func TestClusterServicesMarshal(t *testing.T) {
 func TestClusterServicesUnmarshal(t *testing.T) {
 	actual := &ClusterServiceReports{}
 	err := actual.UnmarshalJSON([]byte(clusterServicesMockJSON))
-	th.AssertNoErr(t, err)
-	th.CheckDeepEquals(t, clusterMockServices, actual)
+	assert.ErrEqual(t, err, nil)
+	assert.Equal(t, actual, clusterMockServices)
 }
 
 func TestClusterResourcesMarshal(t *testing.T) {
@@ -173,6 +175,6 @@ func TestClusterResourcesMarshal(t *testing.T) {
 func TestClusterResourcesUnmarshal(t *testing.T) {
 	actual := &ClusterResourceReports{}
 	err := actual.UnmarshalJSON([]byte(clusterResourcesMockJSON))
-	th.AssertNoErr(t, err)
-	th.CheckDeepEquals(t, clusterMockResources, actual)
+	assert.ErrEqual(t, err, nil)
+	assert.Equal(t, actual, clusterMockResources)
 }

--- a/limes/resources/report_domain_test.go
+++ b/limes/resources/report_domain_test.go
@@ -6,6 +6,8 @@ package limesresources
 import (
 	"testing"
 
+	"go.xyrillian.de/gg/assert"
+
 	th "github.com/sapcc/go-api-declarations/internal/testhelper"
 	"github.com/sapcc/go-api-declarations/limes"
 )
@@ -93,8 +95,8 @@ func TestDomainServicesMarshal(t *testing.T) {
 func TestDomainServicesUnmarshal(t *testing.T) {
 	actual := &DomainServiceReports{}
 	err := actual.UnmarshalJSON([]byte(domainServicesMockJSON))
-	th.AssertNoErr(t, err)
-	th.CheckDeepEquals(t, domainMockServices, actual)
+	assert.ErrEqual(t, err, nil)
+	assert.Equal(t, actual, domainMockServices)
 }
 
 func TestDomainResourcesMarshal(t *testing.T) {
@@ -104,6 +106,6 @@ func TestDomainResourcesMarshal(t *testing.T) {
 func TestDomainResourcesUnmarshal(t *testing.T) {
 	actual := &DomainResourceReports{}
 	err := actual.UnmarshalJSON([]byte(domainResourcesMockJSON))
-	th.AssertNoErr(t, err)
-	th.CheckDeepEquals(t, domainMockResources, actual)
+	assert.ErrEqual(t, err, nil)
+	assert.Equal(t, actual, domainMockResources)
 }

--- a/limes/resources/report_project_test.go
+++ b/limes/resources/report_project_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"go.xyrillian.de/gg/assert"
+
 	th "github.com/sapcc/go-api-declarations/internal/testhelper"
 	"github.com/sapcc/go-api-declarations/limes"
 )
@@ -135,8 +137,8 @@ func TestProjectServicesMarshall(t *testing.T) {
 func TestProjectServicesUnmarshall(t *testing.T) {
 	actual := &ProjectServiceReports{}
 	err := actual.UnmarshalJSON([]byte(projectServicesMockJSON))
-	th.AssertNoErr(t, err)
-	th.CheckDeepEquals(t, projectMockServices, actual)
+	assert.ErrEqual(t, err, nil)
+	assert.Equal(t, actual, projectMockServices)
 }
 
 func TestProjectResourcesMarshall(t *testing.T) {
@@ -146,8 +148,8 @@ func TestProjectResourcesMarshall(t *testing.T) {
 func TestProjectResourcesUnmarshall(t *testing.T) {
 	actual := &ProjectResourceReports{}
 	err := actual.UnmarshalJSON([]byte(projectResourcesMockJSON))
-	th.AssertNoErr(t, err)
-	th.CheckDeepEquals(t, projectMockResources, actual)
+	assert.ErrEqual(t, err, nil)
+	assert.Equal(t, actual, projectMockResources)
 }
 
 func p2time(timestamp int64) *limes.UnixEncodedTime {

--- a/liquid/commitment_test.go
+++ b/liquid/commitment_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"go.xyrillian.de/gg/assert"
 	. "go.xyrillian.de/gg/option"
 
 	th "github.com/sapcc/go-api-declarations/internal/testhelper"
@@ -50,7 +51,7 @@ func TestCloneCommitmentChangeRequest(t *testing.T) {
 	}
 
 	clonedRequest := request.Clone()
-	th.CheckDeepEquals(t, request, clonedRequest)
+	assert.Equal(t, clonedRequest, request)
 	th.CheckFullySeparate(t, request, clonedRequest)
 }
 
@@ -62,7 +63,7 @@ func TestCloneCommitmentChangeResponse(t *testing.T) {
 	}
 
 	clonedResponse := response.Clone()
-	th.CheckDeepEquals(t, response, clonedResponse)
+	assert.Equal(t, clonedResponse, response)
 	th.CheckFullySeparate(t, response, clonedResponse)
 }
 
@@ -128,7 +129,7 @@ func TestCommitmentChangeRequestRequiresConfirmation(t *testing.T) {
 			},
 		},
 	})
-	th.CheckDeepEquals(t, c.RequiresConfirmation(), false)
+	assert.Equal(t, c.RequiresConfirmation(), false)
 
 	// ...but creation of an immediately-confirmed commitment DOES require confirmation
 	c = makeRequest(map[ProjectUUID]ProjectCommitmentChangeset{
@@ -149,7 +150,7 @@ func TestCommitmentChangeRequestRequiresConfirmation(t *testing.T) {
 			},
 		},
 	})
-	th.CheckDeepEquals(t, c.RequiresConfirmation(), true)
+	assert.Equal(t, c.RequiresConfirmation(), true)
 
 	// moving a commitment from "planned" to "pending" on its ConfirmBy time DOES NOT require confirmation...
 	c = makeRequest(map[ProjectUUID]ProjectCommitmentChangeset{
@@ -172,7 +173,7 @@ func TestCommitmentChangeRequestRequiresConfirmation(t *testing.T) {
 			},
 		},
 	})
-	th.CheckDeepEquals(t, c.RequiresConfirmation(), false)
+	assert.Equal(t, c.RequiresConfirmation(), false)
 
 	// ...but moving from either "planned" or "pending" to "confirmed" DOES require confirmation
 	for _, oldStatus := range []CommitmentStatus{CommitmentStatusPlanned, CommitmentStatusPending} {
@@ -195,7 +196,7 @@ func TestCommitmentChangeRequestRequiresConfirmation(t *testing.T) {
 			},
 		})
 		t.Logf("checking confirmation from status %q", oldStatus)
-		th.CheckDeepEquals(t, c.RequiresConfirmation(), true)
+		assert.Equal(t, c.RequiresConfirmation(), true)
 	}
 
 	// creating a commitment in "guaranteed" DOES require confirmation...
@@ -218,7 +219,7 @@ func TestCommitmentChangeRequestRequiresConfirmation(t *testing.T) {
 			},
 		},
 	})
-	th.CheckDeepEquals(t, c.RequiresConfirmation(), true)
+	assert.Equal(t, c.RequiresConfirmation(), true)
 
 	// ...but then moving it into "confirmed" later DOES NOT require additional confirmation
 	c = makeRequest(map[ProjectUUID]ProjectCommitmentChangeset{
@@ -241,7 +242,7 @@ func TestCommitmentChangeRequestRequiresConfirmation(t *testing.T) {
 			},
 		},
 	})
-	th.CheckDeepEquals(t, c.RequiresConfirmation(), false)
+	assert.Equal(t, c.RequiresConfirmation(), false)
 
 	// splitting a commitment DOES NOT require confirmation, regardless of status
 	for _, status := range allAliveStatuses {
@@ -277,7 +278,7 @@ func TestCommitmentChangeRequestRequiresConfirmation(t *testing.T) {
 			},
 		})
 		t.Logf("checking split of status %q", status)
-		th.CheckDeepEquals(t, c.RequiresConfirmation(), false)
+		assert.Equal(t, c.RequiresConfirmation(), false)
 	}
 
 	// moving a commitment from one project to another requires confirmation only in status "guaranteed" or "confirmed"
@@ -319,7 +320,7 @@ func TestCommitmentChangeRequestRequiresConfirmation(t *testing.T) {
 			},
 		})
 		t.Logf("checking move in status %q", status)
-		th.CheckDeepEquals(t, c.RequiresConfirmation(), status == CommitmentStatusGuaranteed || status == CommitmentStatusConfirmed)
+		assert.Equal(t, c.RequiresConfirmation(), status == CommitmentStatusGuaranteed || status == CommitmentStatusConfirmed)
 	}
 
 	// converting a commitment between compatible resources requires confirmation only in status "guaranteed" or "confirmed"
@@ -358,7 +359,7 @@ func TestCommitmentChangeRequestRequiresConfirmation(t *testing.T) {
 			},
 		})
 		t.Logf("checking conversion in status %q", status)
-		th.CheckDeepEquals(t, c.RequiresConfirmation(), status == CommitmentStatusGuaranteed || status == CommitmentStatusConfirmed)
+		assert.Equal(t, c.RequiresConfirmation(), status == CommitmentStatusGuaranteed || status == CommitmentStatusConfirmed)
 	}
 
 	// transitioning into status "expired" is the only type of change to the relevant totals numbers
@@ -384,7 +385,7 @@ func TestCommitmentChangeRequestRequiresConfirmation(t *testing.T) {
 			},
 		})
 		t.Logf("checking expiry in status %q", status)
-		th.CheckDeepEquals(t, c.RequiresConfirmation(), false)
+		assert.Equal(t, c.RequiresConfirmation(), false)
 	}
 
 	// same for hard deletions
@@ -408,7 +409,7 @@ func TestCommitmentChangeRequestRequiresConfirmation(t *testing.T) {
 			},
 		})
 		t.Logf("checking deletion in status %q", status)
-		th.CheckDeepEquals(t, c.RequiresConfirmation(), false)
+		assert.Equal(t, c.RequiresConfirmation(), false)
 	}
 
 	// change of expiration date requires confirmation when already in StatusConfirmed or StatusGuaranteed
@@ -434,6 +435,6 @@ func TestCommitmentChangeRequestRequiresConfirmation(t *testing.T) {
 			},
 		})
 		t.Logf("checking expiresAt extension in status %q", status)
-		th.CheckDeepEquals(t, c.RequiresConfirmation(), status == CommitmentStatusConfirmed || status == CommitmentStatusGuaranteed)
+		assert.Equal(t, c.RequiresConfirmation(), status == CommitmentStatusConfirmed || status == CommitmentStatusGuaranteed)
 	}
 }

--- a/liquid/info_test.go
+++ b/liquid/info_test.go
@@ -9,6 +9,7 @@ import (
 
 	th "github.com/sapcc/go-api-declarations/internal/testhelper"
 
+	"go.xyrillian.de/gg/assert"
 	. "go.xyrillian.de/gg/option"
 )
 
@@ -63,6 +64,6 @@ func TestCloneServiceInfo(t *testing.T) {
 	}
 
 	clonedInfo := info.Clone()
-	th.CheckDeepEquals(t, info, clonedInfo)
+	assert.Equal(t, clonedInfo, info)
 	th.CheckFullySeparate(t, info, clonedInfo)
 }

--- a/liquid/quota_test.go
+++ b/liquid/quota_test.go
@@ -6,6 +6,7 @@ package liquid
 import (
 	"testing"
 
+	"go.xyrillian.de/gg/assert"
 	. "go.xyrillian.de/gg/option"
 
 	th "github.com/sapcc/go-api-declarations/internal/testhelper"
@@ -34,6 +35,6 @@ func TestCloneServiceQuotaRequest(t *testing.T) {
 	}
 
 	clonedRequest := request.Clone()
-	th.CheckDeepEquals(t, request, clonedRequest)
+	assert.Equal(t, clonedRequest, request)
 	th.CheckFullySeparate(t, request, clonedRequest)
 }

--- a/liquid/report_capacity_test.go
+++ b/liquid/report_capacity_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"go.xyrillian.de/gg/assert"
 	. "go.xyrillian.de/gg/option"
 
 	th "github.com/sapcc/go-api-declarations/internal/testhelper"
@@ -31,7 +32,7 @@ func TestCloneServiceCapacityRequest(t *testing.T) {
 	}
 
 	clonedRequest := request.Clone()
-	th.CheckDeepEquals(t, request, clonedRequest)
+	assert.Equal(t, clonedRequest, request)
 	th.CheckFullySeparate(t, request, clonedRequest)
 }
 
@@ -65,6 +66,6 @@ func TestCloneServiceCapacityReport(t *testing.T) {
 	}
 
 	clonedReport := report.Clone()
-	th.CheckDeepEquals(t, report, clonedReport)
+	assert.Equal(t, clonedReport, report)
 	th.CheckFullySeparate(t, report, clonedReport)
 }

--- a/liquid/report_usage_test.go
+++ b/liquid/report_usage_test.go
@@ -8,6 +8,7 @@ import (
 	"math/big"
 	"testing"
 
+	"go.xyrillian.de/gg/assert"
 	. "go.xyrillian.de/gg/option"
 
 	th "github.com/sapcc/go-api-declarations/internal/testhelper"
@@ -29,7 +30,7 @@ func TestCloneServiceUsageRequest(t *testing.T) {
 	}
 
 	clonedRequest := request.Clone()
-	th.CheckDeepEquals(t, request, clonedRequest)
+	assert.Equal(t, clonedRequest, request)
 	th.CheckFullySeparate(t, request, clonedRequest)
 }
 
@@ -75,6 +76,6 @@ func TestCloneServiceUsageReport(t *testing.T) {
 	}
 
 	clonedReport := report.Clone()
-	th.CheckDeepEquals(t, report, clonedReport)
+	assert.Equal(t, clonedReport, report)
 	th.CheckFullySeparate(t, report, clonedReport)
 }

--- a/opts/analyze_test.go
+++ b/opts/analyze_test.go
@@ -8,30 +8,20 @@ import (
 	"testing"
 	"time"
 
+	"go.xyrillian.de/gg/assert"
 	. "go.xyrillian.de/gg/option"
+	"go.xyrillian.de/gg/testcapture"
 
 	"github.com/sapcc/go-api-declarations/opts"
 )
 
 func expectPanic(t *testing.T, panicMsg string, fn func()) {
 	t.Helper()
-	defer func() {
-		t.Helper()
-		r := recover()
-		if r == nil {
-			t.Errorf("expected panic %q, but function did not panic", panicMsg)
-			return
-		}
-		got, ok := r.(string)
-		if !ok {
-			t.Errorf("expected panic with string %q, but got non-string panic: %v", panicMsg, r)
-			return
-		}
-		if got != panicMsg {
-			t.Errorf("expected panic: %s, but got: %s", panicMsg, got)
-		}
-	}()
-	fn()
+	result := testcapture.Capture(t.Context(), t.Name(), func(t assert.TestingTB) { fn() })
+	assert.Equal(t, result, testcapture.Result{
+		Outcome: testcapture.OutcomePanicked,
+		Panic:   panicMsg,
+	})
 }
 
 func expectAnalyzePanic[T any](t *testing.T, panicMsg string) {

--- a/opts/parse_test.go
+++ b/opts/parse_test.go
@@ -13,9 +13,9 @@ import (
 	"testing"
 	"time"
 
+	"go.xyrillian.de/gg/assert"
 	. "go.xyrillian.de/gg/option"
 
-	th "github.com/sapcc/go-api-declarations/internal/testhelper"
 	"github.com/sapcc/go-api-declarations/opts"
 )
 
@@ -104,7 +104,7 @@ func checkParsingHappyPath(t *testing.T, variable, query string, result testOpts
 	if err != nil {
 		t.Fatal(variable + ": " + err.Error())
 	}
-	th.CheckDeepEquals(t, result, to)
+	assert.Equal(t, to, result)
 }
 
 func TestOptParserHappyPaths(t *testing.T) {
@@ -246,7 +246,7 @@ func checkParsingError(t *testing.T, query, errMsg string) {
 	t.Helper()
 	r := httptest.NewRequest(http.MethodGet, "/some/unimportant/path"+query, http.NoBody)
 	_, resultingError := opts.ParseQueryString[testOpts](r.URL.Query())
-	th.AssertErr(t, errMsg, resultingError)
+	assert.ErrEqual(t, resultingError, errMsg)
 }
 
 func TestOptParserErrors(t *testing.T) {
@@ -265,12 +265,12 @@ func TestOptParserErrors(t *testing.T) {
 		String string `q:"string,required"`
 	}
 	_, resultingError := opts.ParseQueryString[testStringRequiredOpts](r.URL.Query())
-	th.AssertErr(t, `missing value for query parameter "string"`, resultingError)
+	assert.ErrEqual(t, resultingError, `missing value for query parameter "string"`)
 	type testStringSliceRequiredOpts struct {
 		StringSlice []string `q:"string_slice,required"`
 	}
 	_, resultingError = opts.ParseQueryString[testStringSliceRequiredOpts](r.URL.Query())
-	th.AssertErr(t, `missing value for query parameter "string_slice"`, resultingError)
+	assert.ErrEqual(t, resultingError, `missing value for query parameter "string_slice"`)
 
 	// unknown parameter
 	checkParsingError(t, "?someRandomParam=foo", `unknown query parameter "someRandomParam"`)

--- a/opts/serialize_test.go
+++ b/opts/serialize_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"go.xyrillian.de/gg/assert"
 	. "go.xyrillian.de/gg/option"
 
-	th "github.com/sapcc/go-api-declarations/internal/testhelper"
 	"github.com/sapcc/go-api-declarations/opts"
 )
 
@@ -26,7 +26,7 @@ func checkSerializingHappyPath(t *testing.T, variable string, input any, expecte
 		if err != nil {
 			t.Fatal(variable + ": " + err.Error())
 		}
-		th.CheckEquals(t, expectedQuery, v.Encode())
+		assert.Equal(t, v.Encode(), expectedQuery)
 	})
 }
 
@@ -176,5 +176,5 @@ func TestBuildQueryStringErrors(t *testing.T) {
 		Name string `q:"name,required"`
 	}
 	_, err := opts.BuildQueryString(requiredOpts{})
-	th.AssertErr(t, `required query parameter "name" not set`, err)
+	assert.ErrEqual(t, err, `required query parameter "name" not set`)
 }


### PR DESCRIPTION
The main part of the diff is that the previous testhelpers did not follow our established convention of the `(t, actual, expected)` argument order for assertions.

There is also the option of rebasing CheckJSONEquals() on package jsonmatch, but since Limes v1 is about to be deprecated anyway, I didn't feel like expending the effort.